### PR TITLE
Seems to work with Core and Framework

### DIFF
--- a/src/libplctag/LibraryExtractor.cs
+++ b/src/libplctag/LibraryExtractor.cs
@@ -13,7 +13,7 @@ namespace libplctag.NativeImport
 
             if (extractDirectory == null)
             {
-                extractDirectory = GetCallingAssemblyDirectory();
+                extractDirectory = GetExecutingAssemblyDirectory();
             }
 
             if (!LibraryExists(extractDirectory))
@@ -23,9 +23,9 @@ namespace libplctag.NativeImport
 
         }
 
-        public static string GetCallingAssemblyDirectory()
+        public static string GetExecutingAssemblyDirectory()
         {
-            string codeBase = Assembly.GetCallingAssembly().CodeBase;
+            string codeBase = Assembly.GetExecutingAssembly().CodeBase;
             UriBuilder uri = new UriBuilder(codeBase);
             string path = Uri.UnescapeDataString(uri.Path);
             return Path.GetDirectoryName(path);


### PR DESCRIPTION
After doing some more research, the library embed/extract actually does seem to be the way things like SQLite and others do it when they are used on a wide variety of platforms.
https://ericsink.com/entries/native_library.html