### PR TITLE
Generic typed arrays#2

### DIFF
--- a/src/Examples/CSharp DotNetCore/CSharp DotNetCore.csproj
+++ b/src/Examples/CSharp DotNetCore/CSharp DotNetCore.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CompareNETObjects" Version="4.66.0" />
     <PackageReference Include="ConsoleTables" Version="2.4.2" />
     <PackageReference Include="RandomTestValues" Version="2.0.5.1" />
   </ItemGroup>

--- a/src/Examples/CSharp DotNetCore/ExampleArray.cs
+++ b/src/Examples/CSharp DotNetCore/ExampleArray.cs
@@ -1,4 +1,5 @@
 ﻿using libplctag;
+using libplctag.DataTypes;
 using System;
 using System.Net;
 using System.Threading;
@@ -14,6 +15,27 @@ namespace CSharpDotNetCore
             //DINT Test Read/Write
             const int ARRAY_LENGTH = 5;
             const int TIMEOUT = 1000;
+            const string gateway = "10.10.10.10";
+            const string path = "1,0";
+
+            //Generics version
+            var dintTag = new Tag<DintMarshaller, int[]>()
+            {
+                Name = "TestDINT",
+                Gateway = gateway,
+                Path = path,
+                PlcType = PlcType.ControlLogix,
+                Protocol = Protocol.ab_eip,
+                ArrayLength = 5,
+                Timeout=TimeSpan.FromSeconds(3),
+            };
+            dintTag.Initialize();
+            dintTag.Read();
+            //Read back value from local memory
+            for (int i = 0; i < ARRAY_LENGTH; i++)
+            {
+                Console.WriteLine($"Value[{i}]: {dintTag.Value[i]}");
+            }
 
             var myArrayTag = new Tag()
             {
@@ -35,7 +57,7 @@ namespace CSharpDotNetCore
             //Read back value from local memory
             for (int i = 0; i < ARRAY_LENGTH; i++)
             {
-                int arrayDint = myArrayTag.GetInt32(i* 4);
+                int arrayDint = myArrayTag.GetInt32(i * 4);
                 Console.WriteLine($"Value[{i}]: {arrayDint}");
             }
 

--- a/src/Examples/CSharp DotNetCore/ExampleAsync.cs
+++ b/src/Examples/CSharp DotNetCore/ExampleAsync.cs
@@ -20,9 +20,10 @@ namespace CSharpDotNetCore
                 Path = "1,0",
                 ElementSize = 4,
                 PlcType = PlcType.ControlLogix,
-                Protocol = Protocol.ab_eip
+                Protocol = Protocol.ab_eip,
+                Timeout = TimeSpan.FromMilliseconds(1000),
             };
-            myTag.Initialize(5000);
+            myTag.Initialize();
 
             myTag.SetInt32(0, 3737);
 
@@ -56,7 +57,7 @@ namespace CSharpDotNetCore
                         Protocol = Protocol.ab_eip,
                         ElementSize = 4
                     };
-                    myTag.Initialize(5000);
+                    myTag.Initialize();
                     return myTag;
                     })
                 .ToList();
@@ -112,7 +113,7 @@ namespace CSharpDotNetCore
                 Protocol = Protocol.ab_eip,
                 ElementSize = 4
             };
-            myTag.Initialize(5000);
+            myTag.Initialize();
 
             int repetitions = 100;
 
@@ -121,8 +122,8 @@ namespace CSharpDotNetCore
             for (int ii = 0; ii < repetitions; ii++)
             {
                 Task.WaitAll(
-                    Task.Run(() => myTag.Read(1000)),
-                    Task.Run(() => myTag.Read(1000))
+                    Task.Run(() => myTag.Read()),
+                    Task.Run(() => myTag.Read())
                     );
             }
             sw.Stop();
@@ -191,9 +192,10 @@ namespace CSharpDotNetCore
                         Path = "1,0",
                         PlcType = PlcType.ControlLogix,
                         Protocol = Protocol.ab_eip,
-                        ElementSize = 4
+                        ElementSize = 4,
+                        Timeout = TimeSpan.FromMilliseconds(1000),
                     };
-                    myTag.Initialize(5000);
+                    myTag.Initialize();
                     return myTag; 
                 })
                 .ToList();
@@ -234,9 +236,10 @@ namespace CSharpDotNetCore
                         Path = "1,0",
                         PlcType = PlcType.ControlLogix,
                         Protocol = Protocol.ab_eip,
-                        ElementSize = 4
+                        ElementSize = 4,
+                        Timeout = TimeSpan.FromMilliseconds(1000),
                     };
-                    myTag.Initialize(5000);
+                    myTag.Initialize();
                     return myTag;
                 })
                 .ToList();

--- a/src/Examples/CSharp DotNetCore/ExampleGenericTag.cs
+++ b/src/Examples/CSharp DotNetCore/ExampleGenericTag.cs
@@ -99,7 +99,7 @@ namespace CSharpDotNetCore
         public static void StringArray()
         {
 
-            var stringTag = new Tag<StringMarshaller, string>()
+            var stringTag = new Tag<StringMarshaller, string[]>()
             {
                 Name = "MY_STRING_1D[0]",
                 Gateway = gateway,
@@ -127,7 +127,7 @@ namespace CSharpDotNetCore
         public static void UDT_Array()
         {
 
-            var sequenceArray = new Tag<SequenceMarshaller, Sequence>()
+            var sequenceArray = new Tag<SequenceMarshaller, Sequence[]>()
             {
                 Name = "MY_SEQUENCE_3D[0,0,0]",
                 Gateway = gateway,
@@ -163,7 +163,7 @@ namespace CSharpDotNetCore
             };
             myBool.Initialize();
 
-            myBool.Value[0] = true;
+            myBool.Value = true;
 
             myBool.Write();
 
@@ -174,7 +174,7 @@ namespace CSharpDotNetCore
         public static void MyBoolArray()
         {
 
-            var myBools = new Tag<BoolMarshaller, bool>()
+            var myBools = new Tag<BoolMarshaller, bool[]>()
             {
                 Name = "MY_BOOL_1D[0]",
                 Gateway = gateway,

--- a/src/Examples/CSharp DotNetCore/ExampleListTags.cs
+++ b/src/Examples/CSharp DotNetCore/ExampleListTags.cs
@@ -16,7 +16,7 @@ namespace CSharpDotNetCore
         public static void Run()
         {
 
-            var tags = new Tag<TagInfoMarshaller, TagInfo>()
+            var tags = new Tag<TagInfoMarshaller, TagInfo[]>()
             {
                 Gateway = "192.168.0.10",
                 Path = "1,0",

--- a/src/Examples/CSharp DotNetCore/ExampleListTags.cs
+++ b/src/Examples/CSharp DotNetCore/ExampleListTags.cs
@@ -18,7 +18,7 @@ namespace CSharpDotNetCore
 
             var tags = new Tag<TagInfoMarshaller, TagInfo[]>()
             {
-                Gateway = "192.168.0.10",
+                Gateway = "10.10.10.10",
                 Path = "1,0",
                 PlcType = PlcType.ControlLogix,
                 Protocol = Protocol.ab_eip,

--- a/src/Examples/CSharp DotNetCore/ExampleListTags.cs
+++ b/src/Examples/CSharp DotNetCore/ExampleListTags.cs
@@ -25,8 +25,8 @@ namespace CSharpDotNetCore
                 Name = "@tags"
             };
 
-            tags.Initialize(TIMEOUT_MS);
-            tags.Read(TIMEOUT_MS);
+            tags.Initialize();
+            tags.Read();
 
             ConsoleTable
                 .From(tags.Value.Select(t => new

--- a/src/Examples/CSharp DotNetCore/Program.cs
+++ b/src/Examples/CSharp DotNetCore/Program.cs
@@ -6,7 +6,7 @@ namespace CSharpDotNetCore
     {
         static void Main(string[] args)
         {
-
+            TestDatatypes.Run();
             //ExampleGenericTag.UDT_Array();
             //ExampleAsync.SyncAsyncMultipleTagComparison();
             //ExampleAsync.AsyncParallelCancellation();

--- a/src/Examples/CSharp DotNetCore/SequenceMarshaller.cs
+++ b/src/Examples/CSharp DotNetCore/SequenceMarshaller.cs
@@ -50,7 +50,7 @@ namespace CSharpDotNetCore
         // provide the value so the tag constructor can use it
         // If ElementSize = null, this will not be passed to the
         // Tag constructor
-        public int? ElementSize => 268;
+        public override int? ElementSize => 268;
 
 
 
@@ -102,7 +102,7 @@ namespace CSharpDotNetCore
             for (int ii = 0; ii < 20; ii++)
             {
                 var timerOffset = offset + 28 + ii * timerMarshaller.ElementSize.Value;
-                TIMERS[ii] = timerMarshaller.Decode(tag, timerOffset, out int timerSize);   // Because TIMER has a static size, we can safely ignore the timerSize.
+                TIMERS[ii] = timerMarshaller.Decode(tag, timerOffset);
             }
 
 
@@ -157,7 +157,7 @@ namespace CSharpDotNetCore
             for (int ii = 0; ii < 20; ii++)
             {
                 var timerOffset = offset + 28 + ii * timerMarshaller.ElementSize.Value;
-                timerMarshaller.Encode(tag, timerOffset, out int timerSize, value.Timer[ii]);
+                timerMarshaller.Encode(tag, timerOffset, value.Timer[ii]);
             }
 
         }
@@ -173,11 +173,6 @@ namespace CSharpDotNetCore
             binary.CopyTo(result, 0);
             return result[0];
         }
-
-
-        void IMarshaller<Sequence[]>.Encode(Tag tag, Sequence[] value) => EncodeArray(tag, value, ElementSize.Value);
-
-        Sequence[] IMarshaller<Sequence[]>.Decode(Tag tag) => DecodeArray(tag, ElementSize.Value);
     }
 
 

--- a/src/Examples/CSharp DotNetCore/SequenceMarshaller.cs
+++ b/src/Examples/CSharp DotNetCore/SequenceMarshaller.cs
@@ -41,7 +41,7 @@ namespace CSharpDotNetCore
     /// set ElementCount = 1).
     /// 
     /// </remarks>
-    public class SequenceMarshaller : Marshaller<Sequence>
+    public class SequenceMarshaller : Marshaller<Sequence>, IMarshaller<Sequence>, IMarshaller<Sequence[]>
     {
 
 
@@ -50,7 +50,7 @@ namespace CSharpDotNetCore
         // provide the value so the tag constructor can use it
         // If ElementSize = null, this will not be passed to the
         // Tag constructor
-        override public int? ElementSize => 268;
+        public int? ElementSize => 268;
 
 
 
@@ -58,7 +58,7 @@ namespace CSharpDotNetCore
         // into a CLR data transfer object
         // The function is called once per array element, so we only 
         // need to decode one array element at a time.
-        override public Sequence Decode(Tag tag, int offset, out int elementSize)
+        override public Sequence Decode(Tag tag, int offset)
         {
 
 
@@ -66,7 +66,7 @@ namespace CSharpDotNetCore
             // If our UDT has a size that does not change, we can set this based on ElementSize
             // Some types have an ElementSize that varies with it's contents (e.g. STRING on some controllers)
             // Those types must wait until they know the actual elementSize before returning it
-            elementSize = ElementSize.Value;
+            //elementSize = ElementSize.Value;
 
 
 
@@ -128,10 +128,8 @@ namespace CSharpDotNetCore
 
 
 
-        override public void Encode(Tag tag, int offset, out int elementSize, Sequence value)
+        override public void Encode(Tag tag, int offset, Sequence value)
         {
-
-            elementSize = ElementSize.Value;
 
             var DINT0 = value.Step_No;
             var DINT1 = value.Next_Step;
@@ -176,6 +174,10 @@ namespace CSharpDotNetCore
             return result[0];
         }
 
+
+        void IMarshaller<Sequence[]>.Encode(Tag tag, Sequence[] value) => EncodeArray(tag, value, ElementSize.Value);
+
+        Sequence[] IMarshaller<Sequence[]>.Decode(Tag tag) => DecodeArray(tag, ElementSize.Value);
     }
 
 

--- a/src/Examples/CSharp DotNetCore/SequenceMarshaller.cs
+++ b/src/Examples/CSharp DotNetCore/SequenceMarshaller.cs
@@ -58,7 +58,7 @@ namespace CSharpDotNetCore
         // into a CLR data transfer object
         // The function is called once per array element, so we only 
         // need to decode one array element at a time.
-        override public Sequence DecodeOne(Tag tag, int offset, out int elementSize)
+        override public Sequence Decode(Tag tag, int offset, out int elementSize)
         {
 
 
@@ -102,7 +102,7 @@ namespace CSharpDotNetCore
             for (int ii = 0; ii < 20; ii++)
             {
                 var timerOffset = offset + 28 + ii * timerMarshaller.ElementSize.Value;
-                TIMERS[ii] = timerMarshaller.DecodeOne(tag, timerOffset, out int timerSize);   // Because TIMER has a static size, we can safely ignore the timerSize.
+                TIMERS[ii] = timerMarshaller.Decode(tag, timerOffset, out int timerSize);   // Because TIMER has a static size, we can safely ignore the timerSize.
             }
 
 
@@ -128,7 +128,7 @@ namespace CSharpDotNetCore
 
 
 
-        override public void EncodeOne(Tag tag, int offset, out int elementSize, Sequence value)
+        override public void Encode(Tag tag, int offset, out int elementSize, Sequence value)
         {
 
             elementSize = ElementSize.Value;
@@ -159,7 +159,7 @@ namespace CSharpDotNetCore
             for (int ii = 0; ii < 20; ii++)
             {
                 var timerOffset = offset + 28 + ii * timerMarshaller.ElementSize.Value;
-                timerMarshaller.EncodeOne(tag, timerOffset, out int timerSize, value.Timer[ii]);
+                timerMarshaller.Encode(tag, timerOffset, out int timerSize, value.Timer[ii]);
             }
 
         }

--- a/src/Examples/CSharp DotNetCore/TestDatatypes.cs
+++ b/src/Examples/CSharp DotNetCore/TestDatatypes.cs
@@ -1,0 +1,111 @@
+﻿using KellermanSoftware.CompareNetObjects;
+using libplctag;
+using libplctag.DataTypes;
+using RandomTestValues;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+
+namespace CSharpDotNetCore
+{
+    class TestDatatypes
+    {
+        private const int DEFAULT_TIMEOUT = 1000;
+        private const string GATEWAY = "10.10.10.10";
+        const string PATH = "1,0";
+        const PlcType PLC_TYPE = PlcType.ControlLogix;
+        const Protocol PROTOCOL = Protocol.ab_eip;
+
+
+        public static void Run()
+        {
+
+            //Bool - Test both cases
+            //Random value would look correct 50% of the time
+            var boolTag = BuildTag<BoolMarshaller, bool>("TestBOOL");
+            TestTag(boolTag, true);
+            TestTag(boolTag, false);
+
+            //Signed Numbers
+            TestTag(BuildTag<SintMarshaller, sbyte>("TestSINT"));
+            TestTag(BuildTag<IntMarshaller, short>("TestINT"));
+            TestTag(BuildTag<DintMarshaller, int>("TestDINT"));
+            TestTag(BuildTag<LintMarshaller, long>("TestLINT"));
+
+            //Logix doesn't support unsigned
+
+            //Floating Points
+            TestTag(BuildTag<RealMarshaller, float>("TestREAL"));
+            //TestTag(new GenericTag<PlcTypeLREAL, double>(gateway, Path, PlcType.Logix, "TestLREAL", timeout));
+
+            //Arrays
+            //var testArray = new int[] {37, 38, 39, 40, 50 };
+            var testArray = RandomValue.Array<int>(5);
+
+            var tagArray = new Tag<DintMarshaller, int[]>()
+            {
+                Name = "TestDINTArray",
+                Gateway = GATEWAY,
+                Path = PATH,
+                PlcType = PLC_TYPE,
+                Protocol = PROTOCOL,
+                Timeout = TimeSpan.FromMilliseconds(DEFAULT_TIMEOUT),
+                ArrayLength=5,
+            };
+            tagArray.Initialize();
+
+            TestTag(tagArray, testArray);
+
+
+        }
+
+
+        private static bool TestTag<M, T>(Tag<M, T> tag) where T : struct where M : IMarshaller<T>, new()
+        {
+            T testValue = RandomValue.Object<T>();
+            return TestTag(tag, testValue);
+        }
+
+        private static bool TestTag<M, T>(Tag<M, T> tag, T testValue) where M : IMarshaller<T>, new()
+        {
+
+            Console.WriteLine($"\r\n*** {tag.Name} [{typeof(M)}] {typeof(T)} ***");
+
+
+            tag.Value = testValue;
+            Console.WriteLine($"Write Value <{typeof(T)}> {testValue} to '{tag.Name}'");
+            tag.Write();
+
+            Console.WriteLine($"Read Value from {tag.Name}");
+            tag.Read();
+
+            T readback = tag.Value;
+
+            CompareLogic compareLogic = new CompareLogic();
+            ComparisonResult result = compareLogic.Compare(readback, testValue);
+
+            if (result.AreEqual) Console.WriteLine($"PASS: Read back matched test value");
+            else Console.WriteLine($"FAIL: Read back did not match test value - [{readback} != {testValue}]");
+
+            return result.AreEqual;
+        }
+
+        private static Tag<M, T> BuildTag<M, T>(string name) where M : IMarshaller<T>, new()
+        {
+            var tag = new Tag<M, T>()
+            {
+                Name = name,
+                Gateway = GATEWAY,
+                Path = PATH,
+                PlcType = PLC_TYPE,
+                Protocol = PROTOCOL,
+                Timeout = TimeSpan.FromMilliseconds(DEFAULT_TIMEOUT),
+            };
+            tag.Initialize();
+            return tag;
+
+        }
+
+    }
+}

--- a/src/libplctag/DataTypes/BoolMarshaller.cs
+++ b/src/libplctag/DataTypes/BoolMarshaller.cs
@@ -5,7 +5,7 @@ namespace libplctag.DataTypes
 
     public class BoolMarshaller : IMarshaller<bool>, IMarshaller<bool[]>
     {
-        public int? ElementSize => throw new NotImplementedException();
+        public int? ElementSize => 1;
 
         public PlcType PlcType { get; set; }
 

--- a/src/libplctag/DataTypes/BoolMarshaller.cs
+++ b/src/libplctag/DataTypes/BoolMarshaller.cs
@@ -3,15 +3,19 @@
 namespace libplctag.DataTypes
 {
 
-    public class BoolMarshaller : Marshaller<bool>
+    public class BoolMarshaller : /*Marshaller<bool>,*/ IMarshaller<bool>, IMarshaller<bool[]>
     {
+        public int? ElementSize => throw new NotImplementedException();
 
-        public override int? ElementCountFromArrayLength(int? elementCount) => (int)Math.Ceiling((double)elementCount.Value / 32.0);
-        public override int? ArrayLengthFromElementCount(int? arrayCount) => arrayCount.Value * 32;
+        public int? SetArrayLength(int? elementCount) => (int)Math.Ceiling((double)elementCount.Value / 32.0);
+        public int? GetArrayLength(Tag tag) => tag.ElementCount.Value * 32;
 
-        override public bool[] Decode(Tag tag)
+        bool IMarshaller<bool>.Decode(Tag tag) => tag.GetBit(0);
+
+        void IMarshaller<bool>.Encode(Tag tag, bool value) => tag.SetBit(0, value);
+
+        bool[] IMarshaller<bool[]>.Decode(Tag tag)
         {
-
             var buffer = new bool[tag.ElementCount.Value * 32];
             for (int ii = 0; ii < tag.ElementCount.Value * 32; ii++)
             {
@@ -20,28 +24,12 @@ namespace libplctag.DataTypes
             return buffer;
         }
 
-
-
-        override public void Encode(Tag tag, bool[] value)
+        void IMarshaller<bool[]>.Encode(Tag tag, bool[] value)
         {
             for (int ii = 0; ii < tag.ElementCount.Value * 32; ii++)
             {
                 tag.SetBit(ii, value[ii]);
             }
         }
-
-
-        public override bool DecodeOne(Tag tag, int offset, out int elementSize)
-        {
-            // This method is not used because we provided new implementations for Decode()
-            throw new System.NotImplementedException();
-        }
-
-        public override void EncodeOne(Tag tag, int offset, out int elementSize, bool value)
-        {
-            // This method is not used because we provided new implementations for Decode()
-            throw new System.NotImplementedException();
-        }
-
     }
 }

--- a/src/libplctag/DataTypes/BoolMarshaller.cs
+++ b/src/libplctag/DataTypes/BoolMarshaller.cs
@@ -3,9 +3,11 @@
 namespace libplctag.DataTypes
 {
 
-    public class BoolMarshaller : /*Marshaller<bool>,*/ IMarshaller<bool>, IMarshaller<bool[]>
+    public class BoolMarshaller : IMarshaller<bool>, IMarshaller<bool[]>
     {
         public int? ElementSize => throw new NotImplementedException();
+
+        public PlcType PlcType { get; set; }
 
         public int? SetArrayLength(int? elementCount) => (int)Math.Ceiling((double)elementCount.Value / 32.0);
         public int? GetArrayLength(Tag tag) => tag.ElementCount.Value * 32;

--- a/src/libplctag/DataTypes/DintMarshaller.cs
+++ b/src/libplctag/DataTypes/DintMarshaller.cs
@@ -1,6 +1,6 @@
 ﻿namespace libplctag.DataTypes
 {
-    public class DintMarshaller : Marshaller<int>
+    public class DintMarshaller : Marshaller<int>, IMarshaller<int>, IMarshaller<int[]>
     {
 
         override public int? ElementSize => 4;
@@ -17,6 +17,15 @@
             tag.SetInt32(offset, value);
         }
 
+        int IMarshaller<int>.Decode(Tag tag)
+        {
+            return Decode(tag)[0];
+        }
 
+        void IMarshaller<int>.Encode(Tag tag, int value)
+        {
+            int[] arrayValue = { value };
+            Encode(tag, arrayValue);
+        }
     }
 }

--- a/src/libplctag/DataTypes/DintMarshaller.cs
+++ b/src/libplctag/DataTypes/DintMarshaller.cs
@@ -2,30 +2,14 @@
 {
     public class DintMarshaller : Marshaller<int>, IMarshaller<int>, IMarshaller<int[]>
     {
-
         override public int? ElementSize => 4;
 
-        override public int DecodeOne(Tag tag, int offset, out int elementSize)
-        {
-            elementSize = ElementSize.Value;
-            return tag.GetInt32(offset * ElementSize.Value);
-        }
+        override public int Decode(Tag tag, int offset) => tag.GetInt32(offset);
 
-        override public void EncodeOne(Tag tag, int offset, out int elementSize, int value)
-        {
-            elementSize = ElementSize.Value;
-            tag.SetInt32(offset, value);
-        }
+        override public void Encode(Tag tag, int offset, int value) => tag.SetInt32(offset, value);
 
-        int IMarshaller<int>.Decode(Tag tag)
-        {
-            return Decode(tag)[0];
-        }
+        int[] IMarshaller<int[]>.Decode(Tag tag)=> DecodeArray(tag, ElementSize.Value);
 
-        void IMarshaller<int>.Encode(Tag tag, int value)
-        {
-            int[] arrayValue = { value };
-            Encode(tag, arrayValue);
-        }
+        void IMarshaller<int[]>.Encode(Tag tag, int[] value) => EncodeArray(tag, value, ElementSize.Value);
     }
 }

--- a/src/libplctag/DataTypes/DintMarshaller.cs
+++ b/src/libplctag/DataTypes/DintMarshaller.cs
@@ -2,13 +2,13 @@
 {
     public class DintMarshaller : Marshaller<int>, IMarshaller<int>, IMarshaller<int[]>
     {
-        override public int? ElementSize => 4;
+        public int? ElementSize => 4;
 
         override public int Decode(Tag tag, int offset) => tag.GetInt32(offset);
 
         override public void Encode(Tag tag, int offset, int value) => tag.SetInt32(offset, value);
 
-        int[] IMarshaller<int[]>.Decode(Tag tag)=> DecodeArray(tag, ElementSize.Value);
+        int[] IMarshaller<int[]>.Decode(Tag tag) => DecodeArray(tag, ElementSize.Value);
 
         void IMarshaller<int[]>.Encode(Tag tag, int[] value) => EncodeArray(tag, value, ElementSize.Value);
     }

--- a/src/libplctag/DataTypes/DintMarshaller.cs
+++ b/src/libplctag/DataTypes/DintMarshaller.cs
@@ -2,14 +2,11 @@
 {
     public class DintMarshaller : Marshaller<int>, IMarshaller<int>, IMarshaller<int[]>
     {
-        public int? ElementSize => 4;
+        public override int? ElementSize => 4;
 
         override public int Decode(Tag tag, int offset) => tag.GetInt32(offset);
 
         override public void Encode(Tag tag, int offset, int value) => tag.SetInt32(offset, value);
 
-        int[] IMarshaller<int[]>.Decode(Tag tag) => DecodeArray(tag, ElementSize.Value);
-
-        void IMarshaller<int[]>.Encode(Tag tag, int[] value) => EncodeArray(tag, value, ElementSize.Value);
     }
 }

--- a/src/libplctag/DataTypes/IMarshaller.cs
+++ b/src/libplctag/DataTypes/IMarshaller.cs
@@ -5,10 +5,11 @@
         int? ElementSize { get; }
         //PlcType PlcType { get; set; }
 
-        int? ArrayLengthFromElementCount(int? arrayLength);
+        int? GetArrayLength(Tag tag);
+        int? SetArrayLength(int? elementCount);
+
         T Decode(Tag tag);
         //T DecodeOne(Tag tag, int offset, out int elementSize);
-        int? ElementCountFromArrayLength(int? elementCount);
         void Encode(Tag tag, T value);
         //void EncodeOne(Tag tag, int offset, out int elementSize, T value);
     }

--- a/src/libplctag/DataTypes/IMarshaller.cs
+++ b/src/libplctag/DataTypes/IMarshaller.cs
@@ -10,29 +10,29 @@
         PlcType PlcType { get; set; }
 
 
-        /// <summary>
-        /// Provide an integer value for ElementSize if you
-        /// want to pass this into the tag constructor
-        /// </summary>
-        int? ElementSize { get; }
-        //PlcType PlcType { get; set; }
+    /// <summary>
+    /// Provide an integer value for ElementSize if you
+    /// want to pass this into the tag constructor
+    /// </summary>
+    int? ElementSize { get; }
+    //PlcType PlcType { get; set; }
 
-        ///// <summary>
-        ///// This will return the number of items defined in a tag 
-        ///// </summary>
-        int? GetArrayLength(Tag tag);
+    ///// <summary>
+    ///// This will return the number of items defined in a tag 
+    ///// </summary>
+    int? GetArrayLength(Tag tag);
 
-        /// <summary>
-        /// This is used to convert the number of array elements
-        /// into the raw element count, which is used by the library.
-        /// Most of the time, this will be the same value, but occasionally
-        /// it is not (e.g. BOOL arrays).
-        /// </summary>
-        int? SetArrayLength(int? elementCount);
+    /// <summary>
+    /// This is used to convert the number of array elements
+    /// into the raw element count, which is used by the library.
+    /// Most of the time, this will be the same value, but occasionally
+    /// it is not (e.g. BOOL arrays).
+    /// </summary>
+    int? SetArrayLength(int? elementCount);
 
-        T Decode(Tag tag);
-        //T DecodeOne(Tag tag, int offset, out int elementSize);
-        void Encode(Tag tag, T value);
-        //void EncodeOne(Tag tag, int offset, out int elementSize, T value);
-    }
+    T Decode(Tag tag);
+    //T DecodeOne(Tag tag, int offset, out int elementSize);
+    void Encode(Tag tag, T value);
+    //void EncodeOne(Tag tag, int offset, out int elementSize, T value);
+}
 }

--- a/src/libplctag/DataTypes/IMarshaller.cs
+++ b/src/libplctag/DataTypes/IMarshaller.cs
@@ -1,0 +1,15 @@
+﻿namespace libplctag.DataTypes
+{
+    public interface IMarshaller<T>
+    {
+        int? ElementSize { get; }
+        //PlcType PlcType { get; set; }
+
+        int? ArrayLengthFromElementCount(int? arrayLength);
+        T Decode(Tag tag);
+        //T DecodeOne(Tag tag, int offset, out int elementSize);
+        int? ElementCountFromArrayLength(int? elementCount);
+        void Encode(Tag tag, T value);
+        //void EncodeOne(Tag tag, int offset, out int elementSize, T value);
+    }
+}

--- a/src/libplctag/DataTypes/IMarshaller.cs
+++ b/src/libplctag/DataTypes/IMarshaller.cs
@@ -3,6 +3,14 @@
     public interface IMarshaller<T>
     {
         /// <summary>
+        /// You can define different marshalling behaviour for different types
+        /// The PlcType is injected during Marshaller instantiation, and
+        /// will be available to you in your marshalling logic
+        /// </summary>
+        PlcType PlcType { get; set; }
+
+
+        /// <summary>
         /// Provide an integer value for ElementSize if you
         /// want to pass this into the tag constructor
         /// </summary>

--- a/src/libplctag/DataTypes/IMarshaller.cs
+++ b/src/libplctag/DataTypes/IMarshaller.cs
@@ -2,10 +2,24 @@
 {
     public interface IMarshaller<T>
     {
+        /// <summary>
+        /// Provide an integer value for ElementSize if you
+        /// want to pass this into the tag constructor
+        /// </summary>
         int? ElementSize { get; }
         //PlcType PlcType { get; set; }
 
+        ///// <summary>
+        ///// This will return the number of items defined in a tag 
+        ///// </summary>
         int? GetArrayLength(Tag tag);
+
+        /// <summary>
+        /// This is used to convert the number of array elements
+        /// into the raw element count, which is used by the library.
+        /// Most of the time, this will be the same value, but occasionally
+        /// it is not (e.g. BOOL arrays).
+        /// </summary>
         int? SetArrayLength(int? elementCount);
 
         T Decode(Tag tag);

--- a/src/libplctag/DataTypes/IntMarshaller.cs
+++ b/src/libplctag/DataTypes/IntMarshaller.cs
@@ -4,13 +4,13 @@
     {
         override public int? ElementSize => 2;
 
-        override public short DecodeOne(Tag tag, int offset, out int elementSize)
+        override public short Decode(Tag tag, int offset, out int elementSize)
         {
             elementSize = ElementSize.Value;
             return tag.GetInt16(offset * ElementSize.Value);
         }
 
-        override public void EncodeOne(Tag tag, int offset, out int elementSize, short value)
+        override public void Encode(Tag tag, int offset, out int elementSize, short value)
         {
             elementSize = ElementSize.Value;
             tag.SetInt16(offset, value);

--- a/src/libplctag/DataTypes/IntMarshaller.cs
+++ b/src/libplctag/DataTypes/IntMarshaller.cs
@@ -1,19 +1,12 @@
 ﻿namespace libplctag.DataTypes
 {
-    public class IntMarshaller : Marshaller<short>
+    public class IntMarshaller : Marshaller<short>, IMarshaller<short>, IMarshaller<short[]>
     {
-        override public int? ElementSize => 2;
+        public override int? ElementSize => 2;
 
-        override public short Decode(Tag tag, int offset, out int elementSize)
-        {
-            elementSize = ElementSize.Value;
-            return tag.GetInt16(offset * ElementSize.Value);
-        }
+        override public short Decode(Tag tag, int offset) => tag.GetInt16(offset);
 
-        override public void Encode(Tag tag, int offset, out int elementSize, short value)
-        {
-            elementSize = ElementSize.Value;
-            tag.SetInt16(offset, value);
-        }
+        override public void Encode(Tag tag, int offset, short value) => tag.SetInt16(offset, value);
+
     }
 }

--- a/src/libplctag/DataTypes/LintMarshaller.cs
+++ b/src/libplctag/DataTypes/LintMarshaller.cs
@@ -4,13 +4,13 @@
     {
         override public int? ElementSize => 8;
 
-        override public long DecodeOne(Tag tag, int offset, out int elementSize)
+        override public long Decode(Tag tag, int offset, out int elementSize)
         {
             elementSize = ElementSize.Value;
             return tag.GetInt64(offset * ElementSize.Value);
         }
 
-        override public void EncodeOne(Tag tag, int offset, out int elementSize, long value)
+        override public void Encode(Tag tag, int offset, out int elementSize, long value)
         {
             elementSize = ElementSize.Value;
             tag.SetInt64(offset, value);

--- a/src/libplctag/DataTypes/LintMarshaller.cs
+++ b/src/libplctag/DataTypes/LintMarshaller.cs
@@ -1,20 +1,12 @@
 ﻿namespace libplctag.DataTypes
 {
-    public class LintMarshaller : Marshaller<long>
+    public class LintMarshaller : Marshaller<long>, IMarshaller<long>, IMarshaller<long[]>
     {
-        override public int? ElementSize => 8;
+        public override int? ElementSize => 8;
 
-        override public long Decode(Tag tag, int offset, out int elementSize)
-        {
-            elementSize = ElementSize.Value;
-            return tag.GetInt64(offset * ElementSize.Value);
-        }
+        override public long Decode(Tag tag, int offset) => tag.GetInt64(offset);
 
-        override public void Encode(Tag tag, int offset, out int elementSize, long value)
-        {
-            elementSize = ElementSize.Value;
-            tag.SetInt64(offset, value);
-        }
+        override public void Encode(Tag tag, int offset, long value) => tag.SetInt64(offset, value);
 
     }
 }

--- a/src/libplctag/DataTypes/LrealMarshaller.cs
+++ b/src/libplctag/DataTypes/LrealMarshaller.cs
@@ -1,21 +1,12 @@
 ﻿namespace libplctag.DataTypes
 {
-    public class LrealMarshaller : Marshaller<double>
+    public class LrealMarshaller : Marshaller<double>, IMarshaller<double>, IMarshaller<double[]>
     {
 
         override public int? ElementSize => 8;
 
-        override public double Decode(Tag tag, int offset, out int elementSize)
-        {
-            elementSize = ElementSize.Value;
-            return tag.GetFloat64(offset * ElementSize.Value);
-        }
+        override public double Decode(Tag tag, int offset) => tag.GetFloat64(offset);
 
-        override public void Encode(Tag tag, int offset, out int elementSize, double value)
-        {
-            elementSize = ElementSize.Value;
-            tag.SetFloat64(offset, value);
-        }
-
+        override public void Encode(Tag tag, int offset, double value)=> tag.SetFloat64(offset, value);
     }
 }

--- a/src/libplctag/DataTypes/LrealMarshaller.cs
+++ b/src/libplctag/DataTypes/LrealMarshaller.cs
@@ -5,13 +5,13 @@
 
         override public int? ElementSize => 8;
 
-        override public double DecodeOne(Tag tag, int offset, out int elementSize)
+        override public double Decode(Tag tag, int offset, out int elementSize)
         {
             elementSize = ElementSize.Value;
             return tag.GetFloat64(offset * ElementSize.Value);
         }
 
-        override public void EncodeOne(Tag tag, int offset, out int elementSize, double value)
+        override public void Encode(Tag tag, int offset, out int elementSize, double value)
         {
             elementSize = ElementSize.Value;
             tag.SetFloat64(offset, value);

--- a/src/libplctag/DataTypes/Marshaller.cs
+++ b/src/libplctag/DataTypes/Marshaller.cs
@@ -1,18 +1,25 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace libplctag.DataTypes
 {
-    public abstract class Marshaller<T>
+    public abstract class Marshaller<T>: IMarshaller<T>, IMarshaller<T[]>
     {
         public PlcType PlcType { get; set; }
+
+        abstract public int? ElementSize { get; }
 
         virtual public int? SetArrayLength(int? elementCount) => elementCount;
 
         virtual public int? GetArrayLength(Tag tag) => tag.ElementCount;
 
 
-        virtual protected T[] DecodeArray(Tag tag, int elementSize)
+        virtual protected T[] DecodeArray(Tag tag)
         {
+            if (ElementSize is null)
+            {
+                throw new ArgumentNullException($"{nameof(ElementSize)} cannot be null for array decoding");
+            }
 
             var buffer = new List<T>();
 
@@ -22,29 +29,38 @@ namespace libplctag.DataTypes
             while (offset < tagSize)
             {
                 buffer.Add(Decode(tag, offset));
-                offset += elementSize;
+                offset += ElementSize.Value;
             }
 
             return buffer.ToArray();
 
         }
 
-        virtual protected void EncodeArray(Tag tag, T[] values, int elementSize)
+        virtual protected void EncodeArray(Tag tag, T[] values)
         {
+            if (ElementSize is null)
+            {
+                throw new ArgumentNullException($"{nameof(ElementSize)} cannot be null for array encoding");
+            }
+
             int offset = 0;
             foreach (var item in values)
             {
                 Encode(tag, offset, item);
-                offset += elementSize;
+                offset += ElementSize.Value;
             }
         }
 
         virtual public T Decode(Tag tag) => Decode(tag, 0);
         public abstract T Decode(Tag tag, int offset);
 
+
         virtual public void Encode(Tag tag, T value) => Encode(tag, 0, value);
         public abstract void Encode(Tag tag, int offset, T value);
 
+        virtual public void Encode(Tag tag, T[] value) => EncodeArray(tag, value);
+
+        T[] IMarshaller<T[]>.Decode(Tag tag) => DecodeArray(tag);
     }
 
 }

--- a/src/libplctag/DataTypes/Marshaller.cs
+++ b/src/libplctag/DataTypes/Marshaller.cs
@@ -30,23 +30,17 @@ namespace libplctag.DataTypes
         /// Most of the time, this will be the same value, but occasionally
         /// it is not (e.g. BOOL arrays).
         /// </summary>
-        virtual public int? ElementCountFromArrayLength(int? elementCount) => elementCount;
-
-
+        virtual public int? SetArrayLength(int? elementCount) => elementCount;
 
 
 
         /// <summary>
         /// The opposite of ElementCountFromArrayLength
         /// </summary>
-        virtual public int? ArrayLengthFromElementCount(int? arrayLength) => arrayLength;
+        virtual public int? GetArrayLength(Tag tag) => tag.ElementCount;
 
 
-
-
-
-
-        virtual public T[] Decode(Tag tag)
+        virtual public T[] DecodeArray(Tag tag, int elementSize)
         {
 
             var buffer = new List<T>();
@@ -56,7 +50,7 @@ namespace libplctag.DataTypes
             int offset = 0;
             while (offset < tagSize)
             {
-                buffer.Add(DecodeOne(tag, offset, out int elementSize));
+                buffer.Add(Decode(tag, offset));
                 offset += elementSize;
             }
 
@@ -64,29 +58,21 @@ namespace libplctag.DataTypes
 
         }
 
-
-
-
-
-
-
-        virtual public void Encode(Tag tag, T[] values)
+        virtual public void EncodeArray(Tag tag, T[] values, int elementSize)
         {
             int offset = 0;
             foreach (var item in values)
             {
-                EncodeOne(tag, offset, out int elementSize, item);
+                Encode(tag, offset, item);
                 offset += elementSize;
             }
         }
 
+        virtual public T Decode(Tag tag) => Decode(tag, 0);
+        public abstract T Decode(Tag tag, int offset);
 
-
-
-
-        public abstract T DecodeOne(Tag tag, int offset, out int elementSize);
-
-        public abstract void EncodeOne(Tag tag, int offset, out int elementSize, T value);
+        virtual public void Encode(Tag tag, T value) => Encode(tag, 0, value);
+        public abstract void Encode(Tag tag, int offset, T value);
 
     }
 

--- a/src/libplctag/DataTypes/Marshaller.cs
+++ b/src/libplctag/DataTypes/Marshaller.cs
@@ -2,7 +2,7 @@
 
 namespace libplctag.DataTypes
 {
-    public abstract class Marshaller<T> : IMarshaller<T>
+    public abstract class Marshaller<T> /*: IMarshaller<T>*/
     {
 
 
@@ -14,33 +14,12 @@ namespace libplctag.DataTypes
         public PlcType PlcType { get; set; }
 
 
-
-        /// <summary>
-        /// Provide an integer value for ElementSize if you
-        /// want to pass this into the tag constructor
-        /// </summary>
-        virtual public int? ElementSize => null;
-
-
-
-
-        /// <summary>
-        /// This is used to convert the number of array elements
-        /// into the element count, which is used by the library.
-        /// Most of the time, this will be the same value, but occasionally
-        /// it is not (e.g. BOOL arrays).
-        /// </summary>
         virtual public int? SetArrayLength(int? elementCount) => elementCount;
 
-
-
-        /// <summary>
-        /// The opposite of ElementCountFromArrayLength
-        /// </summary>
         virtual public int? GetArrayLength(Tag tag) => tag.ElementCount;
 
 
-        virtual public T[] DecodeArray(Tag tag, int elementSize)
+        virtual protected T[] DecodeArray(Tag tag, int elementSize)
         {
 
             var buffer = new List<T>();
@@ -58,7 +37,7 @@ namespace libplctag.DataTypes
 
         }
 
-        virtual public void EncodeArray(Tag tag, T[] values, int elementSize)
+        virtual protected void EncodeArray(Tag tag, T[] values, int elementSize)
         {
             int offset = 0;
             foreach (var item in values)

--- a/src/libplctag/DataTypes/Marshaller.cs
+++ b/src/libplctag/DataTypes/Marshaller.cs
@@ -2,17 +2,9 @@
 
 namespace libplctag.DataTypes
 {
-    public abstract class Marshaller<T> /*: IMarshaller<T>*/
+    public abstract class Marshaller<T>
     {
-
-
-        /// <summary>
-        /// You can define different marshalling behaviour for different types
-        /// The PlcType is injected during Marshaller instantiation, and
-        /// will be available to you in your marshalling logic
-        /// </summary>
         public PlcType PlcType { get; set; }
-
 
         virtual public int? SetArrayLength(int? elementCount) => elementCount;
 

--- a/src/libplctag/DataTypes/Marshaller.cs
+++ b/src/libplctag/DataTypes/Marshaller.cs
@@ -2,7 +2,7 @@
 
 namespace libplctag.DataTypes
 {
-    public abstract class Marshaller<T>
+    public abstract class Marshaller<T> : IMarshaller<T>
     {
 
 

--- a/src/libplctag/DataTypes/RealMarshaller.cs
+++ b/src/libplctag/DataTypes/RealMarshaller.cs
@@ -5,13 +5,13 @@
 
         override public int? ElementSize => 4;
 
-        override public float DecodeOne(Tag tag, int offset, out int elementSize)
+        override public float Decode(Tag tag, int offset, out int elementSize)
         {
             elementSize = ElementSize.Value;
             return tag.GetFloat32(offset* ElementSize.Value);
         }
 
-        override public void EncodeOne(Tag tag, int offset, out int elementSize, float value)
+        override public void Encode(Tag tag, int offset, out int elementSize, float value)
         {
             elementSize = ElementSize.Value;
             tag.SetFloat32(offset, value);

--- a/src/libplctag/DataTypes/RealMarshaller.cs
+++ b/src/libplctag/DataTypes/RealMarshaller.cs
@@ -1,21 +1,13 @@
 ﻿namespace libplctag.DataTypes
 {
-    public class RealMarshaller : Marshaller<float>
+    public class RealMarshaller : Marshaller<float>, IMarshaller<float>, IMarshaller<float[]>
     {
 
         override public int? ElementSize => 4;
 
-        override public float Decode(Tag tag, int offset, out int elementSize)
-        {
-            elementSize = ElementSize.Value;
-            return tag.GetFloat32(offset* ElementSize.Value);
-        }
+        override public float Decode(Tag tag, int offset) => tag.GetFloat32(offset);
 
-        override public void Encode(Tag tag, int offset, out int elementSize, float value)
-        {
-            elementSize = ElementSize.Value;
-            tag.SetFloat32(offset, value);
-        }
+        override public void Encode(Tag tag, int offset, float value) => tag.SetFloat32(offset, value);
 
     }
 }

--- a/src/libplctag/DataTypes/SintMarshaller.cs
+++ b/src/libplctag/DataTypes/SintMarshaller.cs
@@ -5,13 +5,13 @@
 
         override public int? ElementSize => 1;
 
-        override public sbyte DecodeOne(Tag tag, int offset, out int elementSize)
+        override public sbyte Decode(Tag tag, int offset, out int elementSize)
         {
             elementSize = ElementSize.Value;
             return tag.GetInt8(offset * ElementSize.Value);
         }
 
-        override public void EncodeOne(Tag tag, int offset, out int elementSize, sbyte value)
+        override public void Encode(Tag tag, int offset, out int elementSize, sbyte value)
         {
             elementSize = ElementSize.Value;
             tag.SetInt8(offset, value);

--- a/src/libplctag/DataTypes/SintMarshaller.cs
+++ b/src/libplctag/DataTypes/SintMarshaller.cs
@@ -1,21 +1,13 @@
 ﻿namespace libplctag.DataTypes
 {
-    public class SintMarshaller : Marshaller<sbyte>
+    public class SintMarshaller : Marshaller<sbyte>, IMarshaller<sbyte>, IMarshaller<sbyte[]>
     {
 
         override public int? ElementSize => 1;
 
-        override public sbyte Decode(Tag tag, int offset, out int elementSize)
-        {
-            elementSize = ElementSize.Value;
-            return tag.GetInt8(offset * ElementSize.Value);
-        }
+        override public sbyte Decode(Tag tag, int offset) => tag.GetInt8(offset);
 
-        override public void Encode(Tag tag, int offset, out int elementSize, sbyte value)
-        {
-            elementSize = ElementSize.Value;
-            tag.SetInt8(offset, value);
-        }
+        override public void Encode(Tag tag, int offset, sbyte value) => tag.SetInt8(offset, value);
 
     }
 }

--- a/src/libplctag/DataTypes/StringMarshaller.cs
+++ b/src/libplctag/DataTypes/StringMarshaller.cs
@@ -28,7 +28,7 @@ namespace libplctag.DataTypes
         }
 
 
-        override public string DecodeOne(Tag tag, int offset, out int elementSize)
+        override public string Decode(Tag tag, int offset, out int elementSize)
         {
             elementSize = ElementSize.Value;
             switch (PlcType)
@@ -43,7 +43,7 @@ namespace libplctag.DataTypes
             }
         }
 
-        override public void EncodeOne(Tag tag, int offset, out int elementSize, string value)
+        override public void Encode(Tag tag, int offset, out int elementSize, string value)
         {
             elementSize = ElementSize.Value;
             switch (PlcType)

--- a/src/libplctag/DataTypes/StringMarshaller.cs
+++ b/src/libplctag/DataTypes/StringMarshaller.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace libplctag.DataTypes
 {
-    public class StringMarshaller : Marshaller<string>
+    public class StringMarshaller : Marshaller<string>, IMarshaller<string>, IMarshaller<string[]>
     {
 
         const int MAX_CONTROLLOGIX_STRING_LENGTH = 82;
@@ -27,10 +27,8 @@ namespace libplctag.DataTypes
             }
         }
 
-
-        override public string Decode(Tag tag, int offset, out int elementSize)
+        override public string Decode(Tag tag, int offset)
         {
-            elementSize = ElementSize.Value;
             switch (PlcType)
             {
                 case PlcType.ControlLogix: return ControlLogixDecode(tag, offset);
@@ -43,9 +41,8 @@ namespace libplctag.DataTypes
             }
         }
 
-        override public void Encode(Tag tag, int offset, out int elementSize, string value)
+        override public void Encode(Tag tag, int offset, string value)
         {
-            elementSize = ElementSize.Value;
             switch (PlcType)
             {
                 case PlcType.ControlLogix: ControlLogixEncode(tag, offset, value); break;
@@ -57,11 +54,6 @@ namespace libplctag.DataTypes
                 default: break;
             }
         }
-
-
-
-
-
 
         string ControlLogixDecode(Tag tag, int offset)
         {
@@ -93,10 +85,6 @@ namespace libplctag.DataTypes
             }
         }
 
-
-
-
-
         string Plc5Decode(Tag tag, int offset)
         {
             throw new NotImplementedException();
@@ -107,9 +95,6 @@ namespace libplctag.DataTypes
             throw new NotImplementedException();
         }
 
-
-
-
         string Slc500Decode(Tag tag, int offset)
         {
             throw new NotImplementedException();
@@ -119,10 +104,6 @@ namespace libplctag.DataTypes
         {
             throw new NotImplementedException();
         }
-
-
-
-
 
         string LogixPcccDecode(Tag tag, int offset)
         {
@@ -155,9 +136,6 @@ namespace libplctag.DataTypes
             }
         }
 
-
-
-
         string Micro800Decode(Tag tag, int offset)
         {
             throw new NotImplementedException();
@@ -167,12 +145,6 @@ namespace libplctag.DataTypes
         {
             throw new NotImplementedException();
         }
-
-
-
-
-
-
 
         string MicroLogixDecode(Tag tag, int offset)
         {

--- a/src/libplctag/DataTypes/TagInfoMarshaller.cs
+++ b/src/libplctag/DataTypes/TagInfoMarshaller.cs
@@ -21,7 +21,7 @@ namespace libplctag.DataTypes
         const int TAG_STRING_SIZE = 200;
 
 
-        override public TagInfo DecodeOne(Tag tag, int offset, out int elementSize)
+        override public TagInfo Decode(Tag tag, int offset, out int elementSize)
         {
 
             var tagInstanceId = tag.GetUInt32(offset);
@@ -57,7 +57,7 @@ namespace libplctag.DataTypes
 
         }
 
-        public override void EncodeOne(Tag tag, int offset, out int elementSize, TagInfo value)
+        public override void Encode(Tag tag, int offset, out int elementSize, TagInfo value)
         {
             throw new NotImplementedException("This marshaller can only be used to read Tag Information");
         }

--- a/src/libplctag/DataTypes/TagInfoMarshaller.cs
+++ b/src/libplctag/DataTypes/TagInfoMarshaller.cs
@@ -15,13 +15,17 @@ namespace libplctag.DataTypes
         public uint[] Dimensions { get; set; }
     }
 
-    public class TagInfoMarshaller : Marshaller<TagInfo>
+    public class TagInfoMarshaller : IMarshaller<TagInfo[]>
     {
 
         const int TAG_STRING_SIZE = 200;
 
+        public PlcType PlcType { get; set; }
 
-        override public TagInfo Decode(Tag tag, int offset, out int elementSize)
+        //TODO: Is null appropriate since it's unknown?
+        public int? ElementSize => null;
+
+        public TagInfo Decode(Tag tag, int offset, out int elementSize)
         {
 
             var tagInstanceId = tag.GetUInt32(offset);
@@ -57,11 +61,37 @@ namespace libplctag.DataTypes
 
         }
 
-        public override void Encode(Tag tag, int offset, out int elementSize, TagInfo value)
+        public TagInfo[] Decode(Tag tag)
+        {
+            var buffer = new List<TagInfo>();
+
+            var tagSize = tag.GetSize();
+
+            int offset = 0;
+            while (offset < tagSize)
+            {
+                buffer.Add(Decode(tag, offset, out int elementSize));
+                offset += elementSize;
+            }
+
+            return buffer.ToArray();
+        }
+
+        public void Encode(Tag tag, TagInfo[] value)
         {
             throw new NotImplementedException("This marshaller can only be used to read Tag Information");
         }
 
+        public int? GetArrayLength(Tag tag)
+        {
+            //TODO: We know this value after we decode once. SHould we trigger a decode or cache the value after first decode?
+            throw new NotImplementedException();
+        }
+
+        public int? SetArrayLength(int? elementCount)
+        {
+            throw new NotImplementedException("This marshaller can only be used to read Tag Information");
+        }
     }
 
 }

--- a/src/libplctag/DataTypes/TimerMarshaller.cs
+++ b/src/libplctag/DataTypes/TimerMarshaller.cs
@@ -5,15 +5,13 @@ using System.Text;
 
 namespace libplctag.DataTypes
 {
-    public class TimerMarshaller : Marshaller<AbTimer>
+    public class TimerMarshaller : Marshaller<AbTimer>, IMarshaller<AbTimer>, IMarshaller<AbTimer[]>
     {
 
-        override public int? ElementSize => 12;
+        public override int? ElementSize => 12;
 
-        override public AbTimer Decode(Tag tag, int offset, out int elementSize)
+        public override AbTimer Decode(Tag tag, int offset)
         {
-
-            elementSize = ElementSize.Value;
 
             // Needed to look at RsLogix documentation for structure of TIMER
             var DINT2 = tag.GetInt32(offset);
@@ -36,11 +34,8 @@ namespace libplctag.DataTypes
 
         }
 
-        override public void Encode(Tag tag, int offset, out int elementSize, AbTimer value)
+        public override void Encode(Tag tag, int offset, AbTimer value)
         {
-
-            elementSize = ElementSize.Value;
-
             var DINT0 = value.Accumulated;
             var DINT1 = value.Preset;
 

--- a/src/libplctag/DataTypes/TimerMarshaller.cs
+++ b/src/libplctag/DataTypes/TimerMarshaller.cs
@@ -10,7 +10,7 @@ namespace libplctag.DataTypes
 
         override public int? ElementSize => 12;
 
-        override public AbTimer DecodeOne(Tag tag, int offset, out int elementSize)
+        override public AbTimer Decode(Tag tag, int offset, out int elementSize)
         {
 
             elementSize = ElementSize.Value;
@@ -36,7 +36,7 @@ namespace libplctag.DataTypes
 
         }
 
-        override public void EncodeOne(Tag tag, int offset, out int elementSize, AbTimer value)
+        override public void Encode(Tag tag, int offset, out int elementSize, AbTimer value)
         {
 
             elementSize = ElementSize.Value;

--- a/src/libplctag/TagOfT.cs
+++ b/src/libplctag/TagOfT.cs
@@ -46,8 +46,8 @@ namespace libplctag
         }
         public int? ArrayLength
         {
-            get => _marshaller.ArrayLengthFromElementCount(_tag.ElementCount);
-            set => _tag.ElementCount = _marshaller.ElementCountFromArrayLength(value);
+            get => _marshaller.GetArrayLength(_tag);
+            set => _tag.ElementCount = _marshaller.SetArrayLength(value);
         }
         public string Name
         {

--- a/src/libplctag/TagOfT.cs
+++ b/src/libplctag/TagOfT.cs
@@ -9,11 +9,11 @@ using System.Threading.Tasks;
 namespace libplctag
 {
     public class Tag<M, T> : IDisposable
-        where M : Marshaller<T>, new()
+        where M : IMarshaller<T>, new()
     {
 
         private readonly Tag _tag;
-        private readonly Marshaller<T> _marshaller;
+        private readonly IMarshaller<T> _marshaller;
 
         public Tag()
         {
@@ -126,7 +126,7 @@ namespace libplctag
             Dispose();
         }
 
-        public T[] Value { get; set; }
+        public T Value { get; set; }
 
     }
 }


### PR DESCRIPTION
I took a bit of a wrong turn at first, but I ended up putting together something that I'm really happy with regarding how we're handling the conversion code. I moved back to interfaces, but kept the base class in order to duplicate as little code as possible between the marshallers/mappers.

I feel a bit uneasy about the marshaller forcing both a single and an array implementation for a given type, but we can always choose to not use the marshaller and implement directly against the interface.

Good classes to review to go check out the implemenation:

- Simple dataype (DINT, etc)
- Timer -> Uses the marshaller base class but on a non-simple type
- Bool -> Implements against the interface because Bool isn't clean with offsets
- TagInfo -> Requires interesting custom parsing
- Sequence -> UDT that (surprisingly) can still use marshaller base

Really the marshaller base just saves some definition boilerplate and provides simple parsing for the array implementation. I think it can be used with any type that has a fixed `ElementSize`.

Also, I didn't test that I didn't break anything in `TagOfT` or the examples while I was poking at everything. I'll do that before we close the PR. Just wanted to get feedback on this implementation first.