### PR TITLE
Bugfix compactlogix strings

### DIFF
--- a/src/Examples/CSharp DotNetCore/TestDatatypes.cs
+++ b/src/Examples/CSharp DotNetCore/TestDatatypes.cs
@@ -42,23 +42,14 @@ namespace CSharpDotNetCore
             TestTag(BuildTag<RealPlcMapper, float>("TestREAL"));
             //TestTag(new GenericTag<PlcTypeLREAL, double>(gateway, Path, PlcType.Logix, "TestLREAL", timeout));
 
+            //String
+            var tagString = BuildTag<StringPlcMapper, string>("TestSTRING");
+            TestTag(tagString, RandomValue.String(82));
+
             //Arrays
-            //var testArray = new int[] {37, 38, 39, 40, 50 };
-            var testArray = RandomValue.Array<int>(5);
-
-            var tagArray = new Tag<DintPlcMapper, int[]>()
-            {
-                Name = "TestDINTArray",
-                Gateway = GATEWAY,
-                Path = PATH,
-                PlcType = PLC_TYPE,
-                Protocol = PROTOCOL,
-                Timeout = TimeSpan.FromMilliseconds(DEFAULT_TIMEOUT),
-                ArrayDimensions = new int[] { 5 },
-            };
-            tagArray.Initialize();
-
-            TestTag(tagArray, testArray);
+            var tagArray = BuildTag<DintPlcMapper, int[]>("TestDINTArray");
+            tagArray.ArrayDimensions = new int[] { 5 };
+            TestTag(tagArray, RandomValue.Array<int>(5));
 
         }
 

--- a/src/libplctag/DataTypes/StringPlcMapper.cs
+++ b/src/libplctag/DataTypes/StringPlcMapper.cs
@@ -73,7 +73,7 @@ namespace libplctag.DataTypes
             var asciiEncodedString = new byte[actualStringLength];
             for (int ii = 0; ii < actualStringLength; ii++)
             {
-                asciiEncodedString[ii] = tag.GetUInt8(offset + 4 + 2 + ii);
+                asciiEncodedString[ii] = tag.GetUInt8(offset + 4 + ii);
             }
 
             return Encoding.ASCII.GetString(asciiEncodedString);
@@ -90,7 +90,7 @@ namespace libplctag.DataTypes
 
             for (int ii = 0; ii < asciiEncodedString.Length; ii++)
             {
-                tag.SetUInt8(offset + 4 + 2 + ii, Convert.ToByte(asciiEncodedString[ii]));
+                tag.SetUInt8(offset + 4 + ii, Convert.ToByte(asciiEncodedString[ii]));
             }
         }
 

--- a/src/libplctag/DataTypes/StringPlcMapper.cs
+++ b/src/libplctag/DataTypes/StringPlcMapper.cs
@@ -66,14 +66,17 @@ namespace libplctag.DataTypes
 
         string ControlLogixDecode(Tag tag, int offset)
         {
-            var apparentStringLength = tag.GetInt32(offset);
+            const int STRING_LENGTH_HEADER = 4;
+
+            int apparentStringLength = tag.GetInt32(offset);
+
 
             var actualStringLength = Math.Min(apparentStringLength, MAX_CONTROLLOGIX_STRING_LENGTH);
 
             var asciiEncodedString = new byte[actualStringLength];
             for (int ii = 0; ii < actualStringLength; ii++)
             {
-                asciiEncodedString[ii] = tag.GetUInt8(offset + 4 + ii);
+                asciiEncodedString[ii] = tag.GetUInt8(offset + STRING_LENGTH_HEADER + ii);
             }
 
             return Encoding.ASCII.GetString(asciiEncodedString);
@@ -81,6 +84,8 @@ namespace libplctag.DataTypes
 
         void ControlLogixEncode(Tag tag, int offset, string value)
         {
+            const int STRING_LENGTH_HEADER = 4;
+
             if (value.Length > MAX_CONTROLLOGIX_STRING_LENGTH)
                 throw new ArgumentException("String length exceeds maximum for a tag of type STRING");
 
@@ -90,7 +95,7 @@ namespace libplctag.DataTypes
 
             for (int ii = 0; ii < asciiEncodedString.Length; ii++)
             {
-                tag.SetUInt8(offset + 4 + ii, Convert.ToByte(asciiEncodedString[ii]));
+                tag.SetUInt8(offset + STRING_LENGTH_HEADER + ii, Convert.ToByte(asciiEncodedString[ii]));
             }
         }
 

--- a/src/libplctag/libplctag.csproj
+++ b/src/libplctag/libplctag.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>libplctag</AssemblyName>
     <RootNamespace>libplctag</RootNamespace>
     <PackageId>libplctag</PackageId>
-    <Version>0.0.28-alpha02</Version>
+    <Version>0.0.29-alpha01</Version>
     <Authors>libplctag</Authors>
     <PackageLicenseExpression>MPL-2.0</PackageLicenseExpression>
     <PackageDescription>A library for PLC communication</PackageDescription>


### PR DESCRIPTION
There was what looked like a copy-paste error that meant CompactLogix strings had two offsets (+ 4 + 2) in use for retrieving the first character.