### PR TITLE
Add support for Omron PLC

### DIFF
--- a/src/libplctag/DataTypes/BoolPlcMapper.cs
+++ b/src/libplctag/DataTypes/BoolPlcMapper.cs
@@ -46,7 +46,7 @@ namespace libplctag.DataTypes
             }
         }
 
-        bool IPlcMapper<bool>.Decode(Tag tag) => tag.GetUInt8(0) == 255;
+        bool IPlcMapper<bool>.Decode(Tag tag) => tag.PlcType == PlcType.Omron ? tag.GetUInt8(0) != 0 : tag.GetUInt8(0) == 255;
 
         void IPlcMapper<bool>.Encode(Tag tag, bool value) => tag.SetUInt8(0, value == true ? (byte)255 : (byte)0);
 

--- a/src/libplctag/NativeTagWrapper.cs
+++ b/src/libplctag/NativeTagWrapper.cs
@@ -496,7 +496,7 @@ namespace libplctag
                 { "protocol",           Protocol?.ToString() },
                 { "gateway",            Gateway },
                 { "path",               Path },
-                { "plc",                PlcType?.ToString()?.ToLower() },
+                { "plc",                PlcType == libplctag.PlcType.Omron ? "omron-njnx" : PlcType?.ToString()?.ToLower() },
                 { "elem_size",          ElementSize?.ToString() },
                 { "elem_count",         ElementCount?.ToString() },
                 { "name",               Name },

--- a/src/libplctag/PlcType.cs
+++ b/src/libplctag/PlcType.cs
@@ -30,6 +30,11 @@
         /// <summary>
         /// MicroLogix PLC. Synonym for micrologix, mlgx.
         /// </summary>
-        MicroLogix
+        MicroLogix,
+
+        /// <summary>
+        /// Omron PLC. Synonym for omron-njnx, omron-nj, omron-nx, njnx, nx1p2
+        /// </summary>
+        Omron,
     }
 }


### PR DESCRIPTION
This PR adds support for Omron PLCs to the .NET wrapper.

Basically I had to add the `Omron` option to the `PlcType` enumeration.

As in the C library all nemonics for Omron PLC include dashes, which are not allowed in C# enums, I had to create a special case handling on file `NativeTagWrapper.cs`.

Also, booleans are represented differently on the wire than AB PLCs, and I had to take this into account on the `BoolPlcMapper.cs`.

After these changes, I have confirmed with actual Omron hardware (NX1P2) that reading and writing Global Published PLC tags of the following types is possible:

- 16 bits signed integer
- 32 bits signed integer
- 64 bits signed integer
- Boolean
- 32 bits floating point numbers
- 64 bits floating point numbers

My intention in the future is to test arrays and strings.

I'm going to use this new support in a project that I'm developing during the following weeks, and I would be very grateful if you promote this update to the NuGet repository so that I can use it from there.