### PR TITLE
Allow Mapper to Configure Tag prior to initialization

### DIFF
--- a/examples/CSharp DotNetCore/PlcMapper/ExampleListPlc.cs
+++ b/examples/CSharp DotNetCore/PlcMapper/ExampleListPlc.cs
@@ -209,6 +209,11 @@ namespace CSharpDotNetCore.PlcMapper
             //TODO: We know this value after we decode once. SHould we trigger a decode or cache the value after first decode?
             return null;
         }
+
+        public virtual void Configure(Tag tag)
+        {
+            // Do nothing
+        }
     }
 
     public class UdtFieldInfo
@@ -301,6 +306,11 @@ namespace CSharpDotNetCore.PlcMapper
         {
             //TODO: We know this value after we decode once. SHould we trigger a decode or cache the value after first decode?
             return null;
+        }
+
+        public virtual void Configure(Tag tag)
+        {
+            // Do nothing
         }
     }
 }

--- a/examples/CSharp DotNetCore/PlcMapper/ExampleMappers.cs
+++ b/examples/CSharp DotNetCore/PlcMapper/ExampleMappers.cs
@@ -24,6 +24,11 @@ namespace CSharpDotNetCore.PlcMapper
         //Multiply all the dimensions to get total elements
         virtual public int? GetElementCount() => ArrayDimensions?.Aggregate(1, (x, y) => x * y);
 
+        public virtual void Configure(Tag tag)
+        {
+            // Do nothing
+        }
+
         virtual protected T[] DecodeArray(Tag tag)
         {
             if (ElementSize is null)
@@ -97,6 +102,11 @@ namespace CSharpDotNetCore.PlcMapper
             //Multiply dimensions for total elements
             var totalElements = ArrayDimensions.Aggregate(1, (x, y) => x * y);
             return (int)Math.Ceiling((double)totalElements / 32.0);
+        }
+
+        public virtual void Configure(Tag tag)
+        {
+            // Do nothing
         }
 
         public int? SetArrayLength(int? elementCount) => (int)Math.Ceiling((double)elementCount.Value / 32.0);

--- a/examples/CSharp DotNetCore/PlcMapper/TagOfT.cs
+++ b/examples/CSharp DotNetCore/PlcMapper/TagOfT.cs
@@ -288,6 +288,12 @@ namespace CSharpDotNetCore.PlcMapper
         int? GetElementCount();
 
         /// <summary>
+        /// This allows the implementer to configure Tag properties prior to tag Initialization
+        /// </summary>
+        /// <param name="tag"></param>
+        void Configure(Tag tag);
+
+        /// <summary>
         /// This is the method that reads/unpacks the underlying value of the tag
         /// and returns it as a C# type
         /// </summary>


### PR DESCRIPTION
This is a breaking change since it requires IPlcMapper implementations to implement a new method.
As such it will need to go into a 2.x release