### PR TITLE
Implementing really simple Tag classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ In most cases only the  libplctag package will be needed. It can be added in Vis
 
 `dotnet add package libplctag`
 
-### Example Code for an Allen-Bradley CompactLogix/ControlLogix PLC
+### Simple Example Code for an Allen-Bradley CompactLogix/ControlLogix PLC
 
 ```csharp
 // Instantiate the tag with the appropriate mapper and datatype
-var myTag = new Tag<DintPlcMapper, int>()
+var myTag = new TagDint()
 {
     //Name is the full path to tag. "PROGRAM:" is required for C*Logix.
     Name = "PROGRAM:SomeProgram.SomeDINT",
@@ -60,12 +60,14 @@ var myTag = new Tag<DintPlcMapper, int>()
 
 // Read the value from the PLC
 myTag.Read();
+int output = myTag.Value;
 
 // Output to Console
-Console.WriteLine(myTag.Value);
+Console.WriteLine($"SomeProgram.SomeDINT = {output}");
 ```
+In advanced scenarios, tags can be instantiated using generics (ex. `Tag<DintPlcMapper, int>`, `Tag<BoolPlcMapper, bool>`) and can be referenced via an `ITag` interface.
 
-For further usage, see the examples in the example projects:
+For more detail and further usage, see the examples in the example projects:
 
 * [C#](https://github.com/libplctag/libplctag.NET/tree/master/src/Examples/CSharp%20DotNetCore)
 * [VB.NET](https://github.com/libplctag/libplctag.NET/blob/master/src/Examples/VB.NET%20DotNetCore/Program.vb)

--- a/src/Examples/CSharp DotNetCore/ExampleDatatypesSimple.cs
+++ b/src/Examples/CSharp DotNetCore/ExampleDatatypesSimple.cs
@@ -1,0 +1,110 @@
+﻿using libplctag;
+using libplctag.DataTypes.Simple;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+
+namespace CSharpDotNetCore
+{
+    class ExampleDatatypesSimple
+    {
+        const string gateway = "10.10.10.10";
+        const string path = "1,0";
+
+
+        public static void Run()
+        {
+
+            //Bool
+            var boolTag = new TagBool()
+            {
+                Name = "TestBOOL",
+                Gateway = gateway,
+                Path = path,
+                PlcType = PlcType.ControlLogix,
+                Protocol = Protocol.ab_eip
+            };
+            boolTag.Read();
+
+
+            //Signed Numbers
+            var sintTag = new TagSint()
+            {
+                Name = "TestSINT",
+                Gateway = gateway,
+                Path = path,
+                PlcType = PlcType.ControlLogix,
+                Protocol = Protocol.ab_eip
+            };
+            sintTag.Read();
+
+            var intTag = new TagInt()
+            {
+                Name = "TestINT",
+                Gateway = gateway,
+                Path = path,
+                PlcType = PlcType.ControlLogix,
+                Protocol = Protocol.ab_eip
+            };
+            intTag.Read();
+
+
+            var dintTag = new TagDint()
+            {
+                Name = "TestBOOL",
+                Gateway = gateway,
+                Path = path,
+                PlcType = PlcType.ControlLogix,
+                Protocol = Protocol.ab_eip
+            };
+            dintTag.Read();
+
+
+            var lintTag = new TagLint()
+            {
+                Name = "TestLINT",
+                Gateway = gateway,
+                Path = path,
+                PlcType = PlcType.ControlLogix,
+                Protocol = Protocol.ab_eip
+            };
+            lintTag.Read();
+
+
+            //Floating Points
+            var realTag = new TagReal()
+            {
+                Name = "TestREAL",
+                Gateway = gateway,
+                Path = path,
+                PlcType = PlcType.ControlLogix,
+                Protocol = Protocol.ab_eip
+            };
+            realTag.Read();
+
+            //Strings and String Arrays
+            var stringTag = new TagString1D()
+            {
+                Name = "MY_STRING_1D[0]",
+                Gateway = gateway,
+                Path = path,
+                Protocol = Protocol.ab_eip,
+                PlcType = PlcType.ControlLogix,
+                ArrayDimensions = new int[] { 100 },
+            };
+            var r = new Random((int)DateTime.Now.ToBinary());
+
+            for (int ii = 0; ii < stringTag.Value.Length; ii++)
+                stringTag.Value[ii] = r.Next().ToString();
+
+            stringTag.Write();
+
+            Console.WriteLine("DONE");
+
+        }
+
+    }
+
+}

--- a/src/libplctag/DataTypes/Simple/Definitions.cs
+++ b/src/libplctag/DataTypes/Simple/Definitions.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace libplctag.DataTypes.Simple
+{
+
+    public class TagBool : Tag<BoolPlcMapper, bool> { }
+    public class TagBool1D : Tag<BoolPlcMapper, bool[]> { }
+    public class TagBool2D : Tag<BoolPlcMapper, bool[,]> { }
+    public class TagBool3D : Tag<BoolPlcMapper, bool[,,]> { }
+
+
+    public class TagDint : Tag<DintPlcMapper, int> { }
+    public class TagDint1D : Tag<DintPlcMapper, int[]> { }
+    public class TagDint2D : Tag<DintPlcMapper, int[,]> { }
+    public class TagDint3D : Tag<DintPlcMapper, int[,,]> { }
+
+
+    public class TagInt : Tag<IntPlcMapper, short> { }
+    public class TagInt1D : Tag<IntPlcMapper, short[]> { }
+    public class TagInt2D : Tag<IntPlcMapper, short[,]> { }
+    public class TagInt3D : Tag<IntPlcMapper, short[,,]> { }
+
+
+    public class TagLint : Tag<LintPlcMapper, long> { }
+    public class TagLint1D : Tag<LintPlcMapper, long[]> { }
+    public class TagLint2D : Tag<LintPlcMapper, long[,]> { }
+    public class TagLint3D : Tag<LintPlcMapper, long[,,]> { }
+
+
+    public class TagLreal : Tag<LrealPlcMapper, double> { }
+    public class TagLreal1D : Tag<LrealPlcMapper, double[]> { }
+    public class TagLreal2D : Tag<LrealPlcMapper, double[,]> { }
+    public class TagLreal3D : Tag<LrealPlcMapper, double[,,]> { }
+
+
+    public class TagReal : Tag<RealPlcMapper, float> { }
+    public class TagReal1D : Tag<RealPlcMapper, float[]> { }
+    public class TagReal2D : Tag<RealPlcMapper, float[,]> { }
+    public class TagReal3D : Tag<RealPlcMapper, float[,,]> { }
+
+
+    public class TagSint : Tag<SintPlcMapper, sbyte> { }
+    public class TagSint1D : Tag<SintPlcMapper, sbyte[]> { }
+    public class TagSint2D : Tag<SintPlcMapper, sbyte[,]> { }
+    public class TagSint3D : Tag<SintPlcMapper, sbyte[,,]> { }
+
+
+    public class TagString : Tag<StringPlcMapper, string> { }
+    public class TagString1D : Tag<StringPlcMapper, string[]> { }
+    public class TagString2D : Tag<StringPlcMapper, string[,]> { }
+    public class TagString3D : Tag<StringPlcMapper, string[,,]> { }
+
+
+    public class TagTagInfo : Tag<TagInfoPlcMapper, TagInfo[]> { }
+
+    public class TagTimer : Tag<TimerPlcMapper, AbTimer> { }
+    
+    public class TagUdtInfo : Tag<UdtInfoPlcMapper, UdtInfo> { }
+
+}


### PR DESCRIPTION
Closes #155 

I felt a little dirty writing this code, but the intended end user is for devs that are new-er to C#. Generics can be confusing and even more so when a class is defined with two generics. This is really just some helper syntax to keep things simpler. I put these definitions in a single file in their own `libplctag.Datatypes.Simple` - I figured this should help keep them out of the way of more experienced developers.

I'm open to using different naming conventions for the namespace and for the classes - these were just the first that came to mind. Also, if we do want to merge this, I'll update our main page README to highlight the new simple classes.