### PR TITLE
#246 Fix for inappropriate disposal

### DIFF
--- a/src/Examples/CSharp NativeImport/CallbackEx.cs
+++ b/src/Examples/CSharp NativeImport/CallbackEx.cs
@@ -7,7 +7,12 @@ namespace NativeImport_Examples
 {
     public struct MyUserDataClass
     {
-        public int Value = 1234;
+        public int Value;
+
+        public MyUserDataClass()
+        {
+            Value = 1234;
+        }
     }
 
     class CallbackEx

--- a/src/libplctag/NativeTagWrapper.cs
+++ b/src/libplctag/NativeTagWrapper.cs
@@ -344,6 +344,8 @@ namespace libplctag
                     if(GetStatus() == Status.Pending)
                         await createTask.Task;
 
+                    ThrowIfStatusNotOk(createTask.Task.Result);
+
                     _isInitialized = true;
                 }
             }

--- a/src/libplctag/NativeTagWrapper.cs
+++ b/src/libplctag/NativeTagWrapper.cs
@@ -317,11 +317,11 @@ namespace libplctag
 
                 using (cts.Token.Register(() =>
                 {
-                    Abort();
-                    RemoveEvents();
-
                     if (createTasks.TryPop(out var createTask))
                     {
+                        Abort();
+                        RemoveEvents();
+
                         if (token.IsCancellationRequested)
                             createTask.SetCanceled();
                         else
@@ -374,10 +374,10 @@ namespace libplctag
 
                 using (cts.Token.Register(() =>
                 {
-                    Abort();
-
                     if (readTasks.TryPop(out var readTask))
                     {
+                        Abort();
+
                         if (token.IsCancellationRequested)
                             readTask.SetCanceled();
                         else
@@ -417,10 +417,10 @@ namespace libplctag
 
                 using (cts.Token.Register(() =>
                 {
-                    Abort();
-
                     if (writeTasks.TryPop(out var writeTask))
                     {
+                        Abort();
+
                         if (token.IsCancellationRequested)
                             writeTask.SetCanceled();
                         else


### PR DESCRIPTION
This Pull Request fixes inappropriate disposal (for tags that failed to initialize using InitializeAsync).

When InitializeAsync ReadAsync or WriteAsync times out, it also will ensure that it will fail with a ErrorTimeout as opposed to a ErrorAborted