### PR TITLE
Read write omron strings

### DIFF
--- a/src/libplctag/DataTypes/StringPlcMapper.cs
+++ b/src/libplctag/DataTypes/StringPlcMapper.cs
@@ -1,12 +1,12 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 namespace libplctag.DataTypes
 {
     public class StringPlcMapper : PlcMapperBase<string>
     {
+
         override public int? ElementSize
         {
             get
@@ -19,58 +19,14 @@ namespace libplctag.DataTypes
                     case PlcType.LogixPccc: return 84;
                     case PlcType.Micro800: return 256; //To be Confirmed
                     case PlcType.MicroLogix: return 84;
-                    case PlcType.Omron: return 256; //To be Confirmed
                     default: throw new NotImplementedException();
                 }
             }
         }
 
-        override public string Decode(Tag tag, int offset)
-        {
-            if (PlcType == PlcType.Omron)
-            {
-                var bytes = tag.GetBuffer();
-                if (bytes.Length <= 2)
-                    return "";
-                else
-                    return Encoding.ASCII.GetString(bytes, offset + 2, bytes.Length - 2 - offset);
-            }
-            else
-            {
-                return tag.GetString(offset);
-            }
-        }
 
-        override public void Encode(Tag tag, int offset, string value)
-        {
-            if (PlcType == PlcType.Omron)
-            {
-                if (value.Length == 0)
-                {
-                    tag.SetUInt16(0, 0);
-                }
-                else
-                {
-                    if (value.Length > 255)
-                        value = value.Remove(255);
-                    
-                    var bytes = new byte[] { Convert.ToByte(value.Length), 0 }
-                        .Concat(Encoding.ASCII.GetBytes(value))
-                        .ToList();
-                    
-                    if (bytes.Count % 2 == 1)
-                    {
-                        bytes.Add(0);
-                        bytes[0]++;
-                    }
+        override public string Decode(Tag tag, int offset) => tag.GetString(offset);
+        override public void Encode(Tag tag, int offset, string value) => tag.SetString(offset, value);
 
-                    tag.SetBuffer(bytes.ToArray());
-                }
-            }
-            else
-            {
-                tag.SetString(offset, value);
-            }
-        }
     }
 }

--- a/src/libplctag/DataTypes/StringPlcMapper.cs
+++ b/src/libplctag/DataTypes/StringPlcMapper.cs
@@ -1,12 +1,12 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace libplctag.DataTypes
 {
     public class StringPlcMapper : PlcMapperBase<string>
     {
-
         override public int? ElementSize
         {
             get
@@ -19,14 +19,58 @@ namespace libplctag.DataTypes
                     case PlcType.LogixPccc: return 84;
                     case PlcType.Micro800: return 256; //To be Confirmed
                     case PlcType.MicroLogix: return 84;
+                    case PlcType.Omron: return 256; //To be Confirmed
                     default: throw new NotImplementedException();
                 }
             }
         }
 
+        override public string Decode(Tag tag, int offset)
+        {
+            if (PlcType == PlcType.Omron)
+            {
+                var bytes = tag.GetBuffer();
+                if (bytes.Length <= 2)
+                    return "";
+                else
+                    return Encoding.ASCII.GetString(bytes, offset + 2, bytes.Length - 2 - offset);
+            }
+            else
+            {
+                return tag.GetString(offset);
+            }
+        }
 
-        override public string Decode(Tag tag, int offset) => tag.GetString(offset);
-        override public void Encode(Tag tag, int offset, string value) => tag.SetString(offset, value);
+        override public void Encode(Tag tag, int offset, string value)
+        {
+            if (PlcType == PlcType.Omron)
+            {
+                if (value.Length == 0)
+                {
+                    tag.SetUInt16(0, 0);
+                }
+                else
+                {
+                    if (value.Length > 255)
+                        value = value.Remove(255);
+                    
+                    var bytes = new byte[] { Convert.ToByte(value.Length), 0 }
+                        .Concat(Encoding.ASCII.GetBytes(value))
+                        .ToList();
+                    
+                    if (bytes.Count % 2 == 1)
+                    {
+                        bytes.Add(0);
+                        bytes[0]++;
+                    }
 
+                    tag.SetBuffer(bytes.ToArray());
+                }
+            }
+            else
+            {
+                tag.SetString(offset, value);
+            }
+        }
     }
 }

--- a/src/libplctag/NativeTagWrapper.cs
+++ b/src/libplctag/NativeTagWrapper.cs
@@ -474,6 +474,14 @@ namespace libplctag
             return temp;
         }
 
+        public void SetBuffer(byte[] buffer)
+        {
+            ThrowIfAlreadyDisposed();
+
+            GetNativeValueAndThrowOnNegativeResult(_native.plc_tag_set_size, buffer.Length);
+            var result = (Status)_native.plc_tag_set_raw_bytes(nativeTagHandle, 0, buffer, buffer.Length);
+            ThrowIfStatusNotOk(result);
+        }
 
         private int GetIntAttribute(string attributeName)
         {

--- a/src/libplctag/Tag.cs
+++ b/src/libplctag/Tag.cs
@@ -362,6 +362,7 @@ namespace libplctag
         /// This function retrieves a segment of raw, unprocessed bytes from the tag buffer.
         /// </summary>
         public byte[] GetBuffer()                           => _tag.GetBuffer();
+        public void SetBuffer(byte[] newBuffer)             => _tag.SetBuffer(newBuffer);
         public int GetSize()                                => _tag.GetSize();
         public void SetSize(int newSize)                    => _tag.SetSize(newSize);
 

--- a/src/libplctag/TagOfT.cs
+++ b/src/libplctag/TagOfT.cs
@@ -50,7 +50,12 @@ namespace libplctag
         public PlcType? PlcType
         {
             get => _tag.PlcType;
-            set => _tag.PlcType = value;
+            set
+            {
+                _tag.PlcType = value;
+                if(value.HasValue)
+                    _plcMapper.PlcType = value.Value;
+            }
         }
 
         /// <inheritdoc cref="Tag.Name"/>


### PR DESCRIPTION
Changes to allow reading and writing to Strings in Omron PLC.

The default `StringPlcMapper` behavior of calling the native `SetString` method does not work.

@kyle-github I don't know C at all, so I made the necessary modifications in this repository. However, it wolud probably be interesting for this modifications to be translated into C and moved to the base library. If/when such change is applied, I might be able to assist in testing it against a real Omron PLC.