### PR TITLE
Pass PlcType to the _plcMapper

### DIFF
--- a/src/libplctag/TagOfT.cs
+++ b/src/libplctag/TagOfT.cs
@@ -50,7 +50,12 @@ namespace libplctag
         public PlcType? PlcType
         {
             get => _tag.PlcType;
-            set => _tag.PlcType = value;
+            set
+            {
+                _tag.PlcType = value;
+                if(value.HasValue)
+                    _plcMapper.PlcType = value.Value;
+            }
         }
 
         /// <inheritdoc cref="Tag.Name"/>


### PR DESCRIPTION
When accessing `PlcType` from inside a PlcMapper always has the default value, as it is not being written anywhere.

This pull request solves this bug.