### PR TITLE
Expose SetBuffer function in NativeTagWrapper and Tag, allowing more powerful PLC Mappers

### DIFF
--- a/src/libplctag/NativeTagWrapper.cs
+++ b/src/libplctag/NativeTagWrapper.cs
@@ -474,6 +474,14 @@ namespace libplctag
             return temp;
         }
 
+        public void SetBuffer(byte[] buffer)
+        {
+            ThrowIfAlreadyDisposed();
+
+            GetNativeValueAndThrowOnNegativeResult(_native.plc_tag_set_size, buffer.Length);
+            var result = (Status)_native.plc_tag_set_raw_bytes(nativeTagHandle, 0, buffer, buffer.Length);
+            ThrowIfStatusNotOk(result);
+        }
 
         private int GetIntAttribute(string attributeName)
         {

--- a/src/libplctag/Tag.cs
+++ b/src/libplctag/Tag.cs
@@ -362,6 +362,7 @@ namespace libplctag
         /// This function retrieves a segment of raw, unprocessed bytes from the tag buffer.
         /// </summary>
         public byte[] GetBuffer()                           => _tag.GetBuffer();
+        public void SetBuffer(byte[] newBuffer)             => _tag.SetBuffer(newBuffer);
         public int GetSize()                                => _tag.GetSize();
         public void SetSize(int newSize)                    => _tag.SetSize(newSize);
 


### PR DESCRIPTION
Self explanatory title.