### PR TITLE
Exposes GetBuffer(byte[] buffer)

### DIFF
--- a/src/libplctag/NativeTagWrapper.cs
+++ b/src/libplctag/NativeTagWrapper.cs
@@ -468,6 +468,13 @@ namespace libplctag
             return (Status)_native.plc_tag_status(nativeTagHandle);
         }
 
+        public void GetBuffer(byte[] buffer)
+        {
+            ThrowIfAlreadyDisposed();
+            var result = (Status)_native.plc_tag_get_raw_bytes(nativeTagHandle, 0, buffer, buffer.Length);
+            ThrowIfStatusNotOk(result);
+        }
+
         public byte[] GetBuffer()
         {
             ThrowIfAlreadyDisposed();

--- a/src/libplctag/Tag.cs
+++ b/src/libplctag/Tag.cs
@@ -378,11 +378,18 @@ namespace libplctag
         /// <summary>
         /// This function retrieves a segment of raw, unprocessed bytes from the tag buffer.
         /// </summary>
+        /// <remarks>
+        /// Note; initialises a new block of memory.
+        /// If this is problematic, use <see cref="GetBuffer(byte[])"/> instead.
+        /// </remarks>
         public byte[] GetBuffer()                           => _tag.GetBuffer();
 
         /// <summary>
         /// Fills the supplied buffer with the raw, unprocessed bytes from the tag buffer.
         /// </summary>
+        /// <remarks>
+        /// Use this instead of <see cref="GetBuffer()"/> to avoid creating a new block of memory.
+        /// </remarks>
         public void GetBuffer(byte[] buffer)                => _tag.GetBuffer(buffer);
         public void SetBuffer(byte[] newBuffer)             => _tag.SetBuffer(newBuffer);
         public int GetSize()                                => _tag.GetSize();

--- a/src/libplctag/Tag.cs
+++ b/src/libplctag/Tag.cs
@@ -379,6 +379,11 @@ namespace libplctag
         /// This function retrieves a segment of raw, unprocessed bytes from the tag buffer.
         /// </summary>
         public byte[] GetBuffer()                           => _tag.GetBuffer();
+
+        /// <summary>
+        /// Fills the supplied buffer with the raw, unprocessed bytes from the tag buffer.
+        /// </summary>
+        public void GetBuffer(byte[] buffer)                => _tag.GetBuffer(buffer);
         public void SetBuffer(byte[] newBuffer)             => _tag.SetBuffer(newBuffer);
         public int GetSize()                                => _tag.GetSize();
         public void SetSize(int newSize)                    => _tag.SetSize(newSize);


### PR DESCRIPTION
Fulfills #299 by providing an overload for GetBuffer that accepts a byte array.