### PR TITLE
Move calls to Initialize above Timeout token

### DIFF
--- a/src/libplctag/NativeTagWrapper.cs
+++ b/src/libplctag/NativeTagWrapper.cs
@@ -378,12 +378,11 @@ namespace libplctag
         public async Task ReadAsync(CancellationToken token = default)
         {
             ThrowIfAlreadyDisposed();
+            await InitializeAsyncIfRequired(token);
 
             using (var cts = CancellationTokenSource.CreateLinkedTokenSource(token))
             {
                 cts.CancelAfter(Timeout);
-
-                await InitializeAsyncIfRequired(cts.Token);
 
                 using (cts.Token.Register(() =>
                 {
@@ -421,12 +420,11 @@ namespace libplctag
         public async Task WriteAsync(CancellationToken token = default)
         {
             ThrowIfAlreadyDisposed();
+            await InitializeAsyncIfRequired(token);
 
             using (var cts = CancellationTokenSource.CreateLinkedTokenSource(token))
             {
                 cts.CancelAfter(Timeout);
-
-                await InitializeAsyncIfRequired(cts.Token);
 
                 using (cts.Token.Register(() =>
                 {


### PR DESCRIPTION
Currently, as discovered in #327, when using ReadAsync or WriteAsync without first making a call to InitializeAsync and the initialization fails - the exception thrown is of type TaskCancelledException - not LibplctagException.

If I recall correctly, the intention was to throw a  LibplctagException for the libplctag.NET async timeouts, and only to throw a TaskCancelledException if the supplied token is cancelled,


One issue with the attached patch is that there is now two separate timeouts - one for the Initialization, and a second one for the Read - so if there is a 10 second timeout, and a 9 second latency on operations - it will successfully complete in 2*9seconds=18seconds -> maybe the library consumer is expected it to timeout because 18 seconds is larger than the configured timeout.


Either way, this is an API-breaking change so will require some sort of version bump.