### PR TITLE
Issue 178 : Boolean readings do not work with C#

### DIFF
--- a/src/libplctag/DataTypes/BoolPlcMapper.cs
+++ b/src/libplctag/DataTypes/BoolPlcMapper.cs
@@ -53,7 +53,7 @@ namespace libplctag.DataTypes
             }
         }
 
-        bool IPlcMapper<bool>.Decode(Tag tag) => tag.PlcType == PlcType.Omron ? tag.GetUInt8(0) != 0 : tag.GetUInt8(0) == 255;
+        bool IPlcMapper<bool>.Decode(Tag tag) => tag.GetUInt8(0) != 0;
 
         void IPlcMapper<bool>.Encode(Tag tag, bool value) => tag.SetUInt8(0, value == true ? (byte)255 : (byte)0);
 


### PR DESCRIPTION
Always returns False.
Issue : https://github.com/libplctag/libplctag.NET/issues/178