### PR TITLE
ConfigureAwait(false) Changes

### DIFF
--- a/src/libplctag/NativeTagWrapper.cs
+++ b/src/libplctag/NativeTagWrapper.cs
@@ -355,7 +355,7 @@ namespace libplctag
                         nativeTagHandle = result;
 
                     if(GetStatus() == Status.Pending)
-                        await createTask.Task;
+                        await createTask.Task.ConfigureAwait(false);
 
                     ThrowIfStatusNotOk(createTask.Task.Result);
 
@@ -378,7 +378,7 @@ namespace libplctag
         public async Task ReadAsync(CancellationToken token = default)
         {
             ThrowIfAlreadyDisposed();
-            await InitializeAsyncIfRequired(token);
+            await InitializeAsyncIfRequired(token).ConfigureAwait(false);
 
             using (var cts = CancellationTokenSource.CreateLinkedTokenSource(token))
             {
@@ -400,7 +400,7 @@ namespace libplctag
                     var readTask = new TaskCompletionSource<Status>(TaskCreationOptions.RunContinuationsAsynchronously);
                     readTasks.Push(readTask);
                     _native.plc_tag_read(nativeTagHandle, TIMEOUT_VALUE_THAT_INDICATES_ASYNC_OPERATION);
-                    await readTask.Task;
+                    await readTask.Task.ConfigureAwait(false);
                     ThrowIfStatusNotOk(readTask.Task.Result);
                 }
             }
@@ -420,7 +420,7 @@ namespace libplctag
         public async Task WriteAsync(CancellationToken token = default)
         {
             ThrowIfAlreadyDisposed();
-            await InitializeAsyncIfRequired(token);
+            await InitializeAsyncIfRequired(token).ConfigureAwait(false);
 
             using (var cts = CancellationTokenSource.CreateLinkedTokenSource(token))
             {
@@ -442,7 +442,7 @@ namespace libplctag
                     var writeTask = new TaskCompletionSource<Status>(TaskCreationOptions.RunContinuationsAsynchronously);
                     writeTasks.Push(writeTask);
                     _native.plc_tag_write(nativeTagHandle, TIMEOUT_VALUE_THAT_INDICATES_ASYNC_OPERATION);
-                    await writeTask.Task;
+                    await writeTask.Task.ConfigureAwait(false);
                     ThrowIfStatusNotOk(writeTask.Task.Result);
                 }
             }

--- a/src/libplctag/TagOfT.cs
+++ b/src/libplctag/TagOfT.cs
@@ -159,14 +159,14 @@ namespace libplctag
         /// <inheritdoc cref="Tag.InitializeAsync"/>
         public async Task InitializeAsync(CancellationToken token = default)
         {
-            await _tag.InitializeAsync(token);
+            await _tag.InitializeAsync(token).ConfigureAwait(false);
             DecodeAll();
         }
 
         /// <inheritdoc cref="Tag.ReadAsync"/>
         public async Task<T> ReadAsync(CancellationToken token = default)
         {
-            await _tag.ReadAsync(token);
+            await _tag.ReadAsync(token).ConfigureAwait(false);
             DecodeAll();
             return Value;
         }
@@ -181,23 +181,23 @@ namespace libplctag
 
         object ITag.Read() => Read();
 
-        async Task<object> ITag.ReadAsync(CancellationToken token) => await ReadAsync();
+        async Task<object> ITag.ReadAsync(CancellationToken token) => await ReadAsync().ConfigureAwait(false);
 
         /// <inheritdoc cref="Tag.WriteAsync"/>
         public async Task WriteAsync(CancellationToken token = default)
         {
             if (!_tag.IsInitialized)
-                await _tag.InitializeAsync(token);
+                await _tag.InitializeAsync(token).ConfigureAwait(false);
 
             EncodeAll();
-            await _tag.WriteAsync(token);
+            await _tag.WriteAsync(token).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Tag.WriteAsync"/>
         public async Task WriteAsync(T value, CancellationToken token = default)
         {
             Value = value;
-            await WriteAsync(token);
+            await WriteAsync(token).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Tag.Write"/>


### PR DESCRIPTION
Changed all awaits to not run continuations on captured context to prevent deadlocks that occur when a tag is read or written from a UI context.