### PR TITLE
Fix logic error when getting DebugLevel

### DIFF
--- a/src/libplctag/NativeTagWrapper.cs
+++ b/src/libplctag/NativeTagWrapper.cs
@@ -175,10 +175,7 @@ namespace libplctag
             {
                 ThrowIfAlreadyDisposed();
 
-                if (_isInitialized)
-                    return _debugLevel;
-                else
-                    return GetDebugLevel();
+                return _debugLevel;
             }
             set
             {
@@ -534,11 +531,6 @@ namespace libplctag
         private void SetDebugLevel(DebugLevel level)
         {
             _native.plc_tag_set_debug_level((int)level);
-        }
-
-        private DebugLevel GetDebugLevel()
-        {
-            return (DebugLevel)GetIntAttribute("debug");
         }
 
         public bool GetBit(int offset)


### PR DESCRIPTION
The logic should have been if NOT initialized, then get field, otherwise GetDebugLevel - but there is no need to resort to getting debug level because the local field value is always correct.