### PR TITLE
Handle string tag length mismatch and retrieve data

### DIFF
--- a/src/libplctag/NativeTagWrapper.cs
+++ b/src/libplctag/NativeTagWrapper.cs
@@ -591,7 +591,7 @@ namespace libplctag
             var sb = new StringBuilder(stringLength);
             var status = (Status)_native.plc_tag_get_string(nativeTagHandle, offset, sb, stringLength);
             ThrowIfStatusNotOk(status);
-            return sb.ToString().Substring(0, stringLength);
+            return sb.ToString().Substring(0, stringLength < sb.Length ? stringLength : sb.Length);
         }
 
 


### PR DESCRIPTION
In a case where the length of a string tag is larger than the actual data it contains, an ArgumentOutOfRangeException is thrown. 
To handle this case, I made a small modification to retrieve the data.

I encountered a 'string12' tag that actually contains a string of length 10. When I asked a PLC programmer about this, he told me they're just following the MES. According to him, if it turns out to be their fault or the MES's, it makes sense for us to apply a defensive patch.