### PR TITLE
No throw on positive return value from ..._set_size(...)

### DIFF
--- a/src/libplctag/NativeTagWrapper.cs
+++ b/src/libplctag/NativeTagWrapper.cs
@@ -471,11 +471,14 @@ namespace libplctag
                 return result;
         }
 
-        public void SetSize(int newSize)
+        public int SetSize(int newSize)
         {
             ThrowIfAlreadyDisposed();
-            var result = (Status)_native.plc_tag_set_size(nativeTagHandle, newSize);
-            ThrowIfStatusNotOk(result);
+            var result = _native.plc_tag_set_size(nativeTagHandle, newSize);
+            if (result < 0)
+                throw new LibPlcTagException((Status)result);
+            else
+                return result;
         }
 
         public Status GetStatus()

--- a/src/libplctag/Tag.cs
+++ b/src/libplctag/Tag.cs
@@ -410,7 +410,7 @@ namespace libplctag
         /// </summary>
         public byte[] GetByteArrayAttribute(string attributeName)   => _tag.GetByteArrayAttribute(attributeName);
         public int GetSize()                                => _tag.GetSize();
-        public void SetSize(int newSize)                    => _tag.SetSize(newSize);
+        public int SetSize(int newSize)                    => _tag.SetSize(newSize);
 
         /// <summary>
         /// Check the operational status of the tag


### PR DESCRIPTION
After some comments on #359 it became clear that there was a bug in libplctag.NET wrapper code.

Previously it was enforcing the result of set_size to be 0, but the core API says that it is only an error on a negative result and a positive result indicates the previous size.