### PR TITLE
Fixes for various Build Warnings

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         lfs: true 
     

--- a/.github/workflows/update_libplctag_core.yaml
+++ b/.github/workflows/update_libplctag_core.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup git user
         run: |

--- a/src/Examples/CSharp DotNetCore/CSharp DotNetCore.csproj
+++ b/src/Examples/CSharp DotNetCore/CSharp DotNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Examples/CSharp NativeImport/CSharp NativeImport.csproj
+++ b/src/Examples/CSharp NativeImport/CSharp NativeImport.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>NativeImport_Examples</RootNamespace>
   </PropertyGroup>
 

--- a/src/Examples/VB.NET DotNetCore/VB.NET DotNetCore.vbproj
+++ b/src/Examples/VB.NET DotNetCore/VB.NET DotNetCore.vbproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>VB.NET_DotNetCore</RootNamespace>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/LibplctagReadBenchmark/LibplctagReadBenchmark.csproj
+++ b/src/LibplctagReadBenchmark/LibplctagReadBenchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/libplctag.NativeImport.Benchmarks/libplctag.NativeImport.Benchmarks.csproj
+++ b/src/libplctag.NativeImport.Benchmarks/libplctag.NativeImport.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libplctag.NativeImport.Tests/libplctag.NativeImport.Tests.csproj
+++ b/src/libplctag.NativeImport.Tests/libplctag.NativeImport.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/libplctag.Tests/libplctag.Tests.csproj
+++ b/src/libplctag.Tests/libplctag.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/libplctag.sln
+++ b/src/libplctag.sln
@@ -159,14 +159,10 @@ Global
 		{25491EC4-11AD-4A53-9DB0-9D8EAA86A470}.Release|x86.Build.0 = Release|Any CPU
 		{C35C91C5-3121-47F9-BACE-CA437FF46204}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C35C91C5-3121-47F9-BACE-CA437FF46204}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{C35C91C5-3121-47F9-BACE-CA437FF46204}.Debug|x64.Build.0 = Debug|Any CPU
 		{C35C91C5-3121-47F9-BACE-CA437FF46204}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{C35C91C5-3121-47F9-BACE-CA437FF46204}.Debug|x86.Build.0 = Debug|Any CPU
 		{C35C91C5-3121-47F9-BACE-CA437FF46204}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C35C91C5-3121-47F9-BACE-CA437FF46204}.Release|x64.ActiveCfg = Release|Any CPU
-		{C35C91C5-3121-47F9-BACE-CA437FF46204}.Release|x64.Build.0 = Release|Any CPU
 		{C35C91C5-3121-47F9-BACE-CA437FF46204}.Release|x86.ActiveCfg = Release|Any CPU
-		{C35C91C5-3121-47F9-BACE-CA437FF46204}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
* Update Github Actions to latest version to support current node (v20 instead of v16)
* Update .NET projects from .NET6 or .NETCore3.1 to .NET8
* Removed Active Build Configurations for build project as per NUKE warnings