### PR TITLE
Remove dependency on System.Net.Primitives

### DIFF
--- a/src/libplctag.NativeImport/libplctag.NativeImport.csproj
+++ b/src/libplctag.NativeImport/libplctag.NativeImport.csproj
@@ -33,8 +33,4 @@
     <None Include="..\..\docs\libplctag.NativeImport.md" Pack="true" PackagePath="\README.md"/>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Net.Primitives" Version="4.3.1" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
This is a relic from the pre v1.0.0 days, where the IP Address type was (incorrectly) used to force a strong type onto Gateway.