### PR TITLE
Fix repeated log event subscription bug

### DIFF
--- a/src/libplctag/LibPlcTag.cs
+++ b/src/libplctag/LibPlcTag.cs
@@ -66,6 +66,8 @@ namespace libplctag
             var statusAfterRegistration = (Status)_native.plc_tag_register_logger(loggerDelegate);
             if (statusAfterRegistration != Status.Ok)
                 throw new LibPlcTagException(statusAfterRegistration);
+
+            alreadySubscribedToEvents = true;
         }
 
         static void invokeLogEvent(int tag_id, int debug_level, string message)


### PR DESCRIPTION
Ran into this bug when a logging event was added to `LibPlcTag.LogEvent` more than once. This led to an error from `plc_tag_register_logger` being called more than once. Seems like the `alreadySubscribedToEvents` flag wasn't being set true after the first subscription.

