### PR TITLE
fix bug: Error in converting 3D array to 1D array (ArrayExtensions.To1DArray)

### DIFF
--- a/src/libplctag/DataTypes/Extensions/ArrayExtensions.cs
+++ b/src/libplctag/DataTypes/Extensions/ArrayExtensions.cs
@@ -57,7 +57,7 @@ namespace libplctag.DataTypes.Extensions
             {
                 for (int j = 0; j <= input.GetUpperBound(1); j++)
                 {
-                    for (int k = 0; k < input.GetUpperBound(2); k++)
+                    for (int k = 0; k <= input.GetUpperBound(2); k++)
                     {
                         result[write++] = input[i, j, k];
                     }

--- a/src/libplctag/DataTypes/Extensions/ArrayExtensions.cs
+++ b/src/libplctag/DataTypes/Extensions/ArrayExtensions.cs
@@ -108,7 +108,7 @@ namespace libplctag.DataTypes.Extensions
                 {
                     for (int k = 0; k < length; k++)
                     {
-                        output[i, j, k] = input[i * height * width + j * width + k];
+                        output[i, j, k] = input[i * width * length + j * length + k];
                     }
                 }
             }


### PR DESCRIPTION
How I discovered it: When I wrote a 3D array into the PLC, I found that the written data was always missing the last number of the third index. Finally, I found that there was a problem when converting the 3D array to a 1D array during encoding.