### PR TITLE
Delete src/libplctag.NativeImport/runtimes/win-arm/native/plctag.dll

### DIFF
--- a/src/libplctag.NativeImport/runtimes/win-arm/native/plctag.dll
+++ b/src/libplctag.NativeImport/runtimes/win-arm/native/plctag.dll
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7dbc22201a75fe5fa227575d647bddb99ed022f60044e1d5c4f39a1bff8e1b3b
-size 309760


### PR DESCRIPTION
Removes win-arm binary that is no longer shipped by libplctag