### PR TITLE
Change libplctag.NET -> libplctag.NativeImport to a ProjectReference …

### DIFF
--- a/src/libplctag/libplctag.csproj
+++ b/src/libplctag/libplctag.csproj
@@ -19,7 +19,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="libplctag.NativeImport" Version="2.0.0-alpha.5" />
+    <ProjectReference Include="..\libplctag.NativeImport\libplctag.NativeImport.csproj">
+      <PrivateAssets>contentfiles;analyzers</PrivateAssets>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
…as it is simpler to

Previously, the changes for NativeImport and the primary package need to be staged because it referenced the nuget.org package, requiring the NativeImport changes to be released and uploaded before the primary package could be changed. SDK-style projects still reference nuget.org packages, so moving to a ProjectReference will still work, but allows both projects to be shipped simultaneously.