### PR TITLE
Add `Span<byte>` overloads for `get/set_raw_bytes`

### DIFF
--- a/src/libplctag.NativeImport/NativeMethods.cs
+++ b/src/libplctag.NativeImport/NativeMethods.cs
@@ -257,9 +257,9 @@ namespace libplctag.NativeImport
 
 
         [DllImport(DLL_NAME, EntryPoint = nameof(plc_tag_get_raw_bytes), CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        public static extern int plc_tag_get_raw_bytes(Int32 tag_id, int start_offset, [Out] byte[] buffer, int buffer_length);
+        public unsafe static extern int plc_tag_get_raw_bytes(Int32 tag_id, int start_offset, byte* buffer, int buffer_length);
 
         [DllImport(DLL_NAME, EntryPoint = nameof(plc_tag_set_raw_bytes), CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        public static extern int plc_tag_set_raw_bytes(Int32 tag_id, int start_offset, [In] byte[] buffer, int buffer_length);
+        public unsafe static extern int plc_tag_set_raw_bytes(Int32 tag_id, int start_offset, byte* buffer, int buffer_length);
     }
 }

--- a/src/libplctag.NativeImport/libplctag.NativeImport.csproj
+++ b/src/libplctag.NativeImport/libplctag.NativeImport.csproj
@@ -33,10 +33,12 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <DebugType>embedded</DebugType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>
 	  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+	  <PackageReference Include="System.Memory" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libplctag.NativeImport/plctag.cs
+++ b/src/libplctag.NativeImport/plctag.cs
@@ -295,12 +295,34 @@ namespace libplctag.NativeImport
 
         public static int plc_tag_get_raw_bytes(Int32 tag_id, int start_offset, byte[] buffer, int buffer_length)
         {
-            return NativeMethods.plc_tag_get_raw_bytes(tag_id, start_offset, buffer, buffer_length);
+            return plc_tag_get_raw_bytes(tag_id, start_offset, buffer.AsSpan(0, buffer_length));
+        }
+
+        public static int plc_tag_get_raw_bytes(Int32 tag_id, int start_offset, Span<byte> buffer)
+        {
+            unsafe
+            {
+                fixed (byte* ptr = buffer)
+                {
+                    return NativeMethods.plc_tag_get_raw_bytes(tag_id, start_offset, ptr, buffer.Length);
+                }
+            }
         }
 
         public static int plc_tag_set_raw_bytes(Int32 tag_id, int start_offset, byte[] buffer, int buffer_length)
         {
-            return NativeMethods.plc_tag_set_raw_bytes(tag_id, start_offset, buffer, buffer_length);
+            return plc_tag_set_raw_bytes(tag_id, start_offset, new ReadOnlySpan<byte>(buffer, 0, buffer_length));
+        }
+
+        public static int plc_tag_set_raw_bytes(Int32 tag_id, int start_offset, ReadOnlySpan<byte> buffer)
+        {
+            unsafe
+            {
+                fixed (byte* ptr = buffer)
+                {
+                    return NativeMethods.plc_tag_set_raw_bytes(tag_id, start_offset, ptr, buffer.Length);
+                }
+            }
         }
 
 


### PR DESCRIPTION
This is anticipated to be part 1 of a series of performance-oriented changes around native interop.